### PR TITLE
feat: epic support for GitHub backend

### DIFF
--- a/agentharness/brainstorm.py
+++ b/agentharness/brainstorm.py
@@ -325,12 +325,11 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
         store = create_artifact_store(config, feature_id=branch_name)
 
         # 4. Create branch (or verify previous sibling done)
-        default_branch = await gh_client.get_default_branch()
-        ref = await gh_client.get_ref(f"heads/{default_branch}")
-        sha = ref["object"]["sha"]
-
         if epic_position is None or epic_position == 1:
             # Non-epic or first epic child: create the branch
+            default_branch = await gh_client.get_default_branch()
+            ref = await gh_client.get_ref(f"heads/{default_branch}")
+            sha = ref["object"]["sha"]
             try:
                 await gh_client.create_ref(f"refs/heads/{branch_name}", sha)
                 log.info("Created branch %s", branch_name)

--- a/agentharness/brainstorm.py
+++ b/agentharness/brainstorm.py
@@ -300,28 +300,75 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
         issue_number = int(match["number"])
         brief_content = match.get("body") or ""
 
-        # 2. Create branch (tolerate 'already exists')
+        # 2. Detect epic parent (sub-issue relationship)
+        parent_issue = await gh_client.get_parent_issue(issue_number)
+        epic_parent: int | None = None
+        epic_position: int | None = None
+        epic_branch: str | None = None
+        branch_name = feature_id  # default for non-epic features
+
+        if parent_issue is not None:
+            parent_number = int(parent_issue["number"])
+            epic_branch = "epic-" + slug_title(parent_issue.get("title") or "")
+            branch_name = epic_branch
+            epic_parent = parent_number
+
+            sub_issues = await gh_client.list_sub_issues(parent_number)
+            sub_numbers = [int(s["number"]) for s in sub_issues]
+            try:
+                epic_position = sub_numbers.index(issue_number) + 1
+            except ValueError:
+                epic_position = len(sub_numbers) + 1  # fallback: treat as last
+
+        # 3. Create branch (or verify previous sibling done)
         default_branch = await gh_client.get_default_branch()
         ref = await gh_client.get_ref(f"heads/{default_branch}")
         sha = ref["object"]["sha"]
-        try:
-            await gh_client.create_ref(f"refs/heads/{feature_id}", sha)
-            log.info("Created feature branch %s", feature_id)
-        except GitHubApiError as exc:
-            if exc.status_code == 422:
-                log.info("Feature branch %s already exists — skipping creation", feature_id)
-            else:
-                raise
 
-        # 3. Upload brief
+        if epic_position is None or epic_position == 1:
+            # Non-epic or first epic child: create the branch
+            try:
+                await gh_client.create_ref(f"refs/heads/{branch_name}", sha)
+                log.info("Created branch %s", branch_name)
+            except GitHubApiError as exc:
+                if exc.status_code == 422:
+                    log.info("Branch %s already exists — skipping creation", branch_name)
+                else:
+                    raise
+        else:
+            # Epic child N>1: verify previous sibling is done
+            sub_issues = await gh_client.list_sub_issues(epic_parent)  # type: ignore[arg-type]
+            prev_sibling = sub_issues[epic_position - 2]  # 0-indexed, previous sibling
+            prev_title = prev_sibling.get("title") or ""
+            prev_feature_id = f"feat-{slug_title(prev_title)}"
+            try:
+                prev_state = await state_mgr.get(prev_feature_id)
+                is_done = prev_state.status == FeatureStatus.done
+            except KeyError:
+                is_done = False
+
+            if not is_done:
+                raise ValueError(
+                    f"Epic child #{issue_number} (position {epic_position}) cannot start: "
+                    f"previous sibling {prev_feature_id!r} is not done"
+                )
+            log.info(
+                "Epic child #%d (position %d): previous sibling %s is done — skipping branch creation",
+                issue_number, epic_position, prev_feature_id,
+            )
+
+        # 4. Upload brief
         await store.upload(artifact_path(feature_id, "brief.md"), brief_content)
 
-        # 4. Build state and patch the issue
+        # 5. Build state and patch the issue
         state = FeatureState(
             feature_id=feature_id,
             status=FeatureStatus.brainstormed,
             state_issue_number=issue_number,
-            branch_name=feature_id,
+            branch_name=branch_name,
+            epic_parent=epic_parent,
+            epic_position=epic_position,
+            epic_branch=epic_branch,
             config=PipelineConfig(
                 max_revisions=config.defaults.max_revisions,
                 max_analyst_iterations=config.max_analyst_iterations,

--- a/agentharness/brainstorm.py
+++ b/agentharness/brainstorm.py
@@ -280,8 +280,8 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
     expected_slug = feature_id.removeprefix("feat-")
 
     gh_client = GitHubClient.from_config(config)
-    store = create_artifact_store(config, feature_id=feature_id)
     state_mgr = create_state_manager(config)
+    store = None
     try:
         # 1. Find the matching issue
         issues = await gh_client.list_issues(labels=[config.github.feature_marker])
@@ -306,6 +306,7 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
         epic_position: int | None = None
         epic_branch: str | None = None
         branch_name = feature_id  # default for non-epic features
+        sub_issues: list[dict] = []
 
         if parent_issue is not None:
             parent_number = int(parent_issue["number"])
@@ -320,7 +321,10 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
             except ValueError:
                 epic_position = len(sub_numbers) + 1  # fallback: treat as last
 
-        # 3. Create branch (or verify previous sibling done)
+        # 3. Create store with correct branch (branch_name now known)
+        store = create_artifact_store(config, feature_id=branch_name)
+
+        # 4. Create branch (or verify previous sibling done)
         default_branch = await gh_client.get_default_branch()
         ref = await gh_client.get_ref(f"heads/{default_branch}")
         sha = ref["object"]["sha"]
@@ -336,8 +340,7 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
                 else:
                     raise
         else:
-            # Epic child N>1: verify previous sibling is done
-            sub_issues = await gh_client.list_sub_issues(epic_parent)  # type: ignore[arg-type]
+            # Epic child N>1: verify previous sibling is done (reuse sub_issues from above)
             prev_sibling = sub_issues[epic_position - 2]  # 0-indexed, previous sibling
             prev_title = prev_sibling.get("title") or ""
             prev_feature_id = f"feat-{slug_title(prev_title)}"
@@ -357,10 +360,10 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
                 issue_number, epic_position, prev_feature_id,
             )
 
-        # 4. Upload brief
+        # 5. Upload brief
         await store.upload(artifact_path(feature_id, "brief.md"), brief_content)
 
-        # 5. Build state and patch the issue
+        # 6. Build state and patch the issue
         state = FeatureState(
             feature_id=feature_id,
             status=FeatureStatus.brainstormed,
@@ -378,7 +381,8 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
         log.info("Auto-converted raw issue #%d → feature %s", issue_number, feature_id)
     finally:
         await gh_client.close()
-        await store.close()
+        if store is not None:
+            await store.close()
         await state_mgr.close()
 
 

--- a/agentharness/brainstorm.py
+++ b/agentharness/brainstorm.py
@@ -364,6 +364,7 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
         await store.upload(artifact_path(feature_id, "brief.md"), brief_content)
 
         # 6. Build state and patch the issue
+        epic_total: int | None = len(sub_issues) if sub_issues else None
         state = FeatureState(
             feature_id=feature_id,
             status=FeatureStatus.brainstormed,
@@ -372,6 +373,7 @@ async def _convert_raw_issue(feature_id: str, config: Config) -> None:
             epic_parent=epic_parent,
             epic_position=epic_position,
             epic_branch=epic_branch,
+            epic_total=epic_total,
             config=PipelineConfig(
                 max_revisions=config.defaults.max_revisions,
                 max_analyst_iterations=config.max_analyst_iterations,

--- a/agentharness/cli.py
+++ b/agentharness/cli.py
@@ -13,8 +13,57 @@ from rich import box
 
 from agentharness.config import load_config
 from agentharness.storage import create_state_manager
+from agentharness.github_labels import EPIC_PAUSED
+from agentharness.github_client import GitHubClient
+from agentharness.brainstorm import enqueue_planner
 
 console = Console()
+
+
+async def _implement_with_epic_check(feature_id: str, config) -> None:
+    """Check if feature is an epic child with paused parent before enqueuing."""
+    # GitHub backend only
+    if config.storage_backend != "github":
+        await enqueue_planner(feature_id, config)
+        console.print(f"[green]Pipeline started:[/green] {feature_id}")
+        console.print(f"Monitor: [bold]agentharness watch[/bold]")
+        return
+
+    state_mgr = create_state_manager(config)
+    gh_client = GitHubClient.from_config(config)
+
+    try:
+        # Try to load existing state
+        try:
+            state = await state_mgr.get(feature_id)
+        except KeyError:
+            # Raw issue with no state yet — enqueue_planner handles preconditions
+            await enqueue_planner(feature_id, config)
+            console.print(f"[green]Pipeline started:[/green] {feature_id}")
+            console.print(f"Monitor: [bold]agentharness watch[/bold]")
+            return
+
+        # Check if this is an epic child
+        if state.epic_parent is not None:
+            parent_issue = await gh_client.get_issue(state.epic_parent)
+            parent_labels = [label["name"] for label in parent_issue.get("labels", [])]
+
+            if EPIC_PAUSED in parent_labels:
+                console.print("[red]Epic is paused[/red] — a child feature has failed.")
+                console.print(f"Parent epic: #{state.epic_parent}")
+                console.print(
+                    "To retry: fix the failing child's brief, remove the epic:paused label from "
+                    f"#{state.epic_parent}, then re-run this command."
+                )
+                raise SystemExit(1)
+
+        # Non-epic or parent is not paused — proceed
+        await enqueue_planner(feature_id, config)
+        console.print(f"[green]Pipeline started:[/green] {feature_id}")
+        console.print(f"Monitor: [bold]agentharness watch[/bold]")
+
+    finally:
+        await gh_client.close()
 
 
 @click.group()
@@ -58,10 +107,7 @@ def submit(ctx: click.Context, brief_file: str) -> None:
 def implement(ctx: click.Context, feature_id: str) -> None:
     """Start the pipeline for an uploaded feature brief."""
     config = load_config(ctx.obj.get("config_path"))
-    from agentharness.brainstorm import enqueue_planner
-    asyncio.run(enqueue_planner(feature_id, config))
-    console.print(f"[green]Pipeline started:[/green] {feature_id}")
-    console.print(f"Monitor: [bold]agentharness watch[/bold]")
+    asyncio.run(_implement_with_epic_check(feature_id, config))
 
 
 @main.command("observe")

--- a/agentharness/cli.py
+++ b/agentharness/cli.py
@@ -14,10 +14,16 @@ from rich import box
 from agentharness.config import load_config
 from agentharness.storage import create_state_manager
 from agentharness.github_labels import EPIC_PAUSED
-from agentharness.github_client import GitHubClient
+from agentharness.github_client import GitHubClient, GitHubApiError
 from agentharness.brainstorm import enqueue_planner
 
 console = Console()
+
+
+def _print_started(feature_id: str) -> None:
+    """Print pipeline start confirmation."""
+    console.print(f"[green]Pipeline started:[/green] {feature_id}")
+    console.print(f"Monitor: [bold]agentharness watch[/bold]")
 
 
 async def _implement_with_epic_check(feature_id: str, config) -> None:
@@ -25,8 +31,7 @@ async def _implement_with_epic_check(feature_id: str, config) -> None:
     # GitHub backend only
     if config.storage_backend != "github":
         await enqueue_planner(feature_id, config)
-        console.print(f"[green]Pipeline started:[/green] {feature_id}")
-        console.print(f"Monitor: [bold]agentharness watch[/bold]")
+        _print_started(feature_id)
         return
 
     state_mgr = create_state_manager(config)
@@ -39,28 +44,32 @@ async def _implement_with_epic_check(feature_id: str, config) -> None:
         except KeyError:
             # Raw issue with no state yet — enqueue_planner handles preconditions
             await enqueue_planner(feature_id, config)
-            console.print(f"[green]Pipeline started:[/green] {feature_id}")
-            console.print(f"Monitor: [bold]agentharness watch[/bold]")
+            _print_started(feature_id)
             return
 
         # Check if this is an epic child
         if state.epic_parent is not None:
-            parent_issue = await gh_client.get_issue(state.epic_parent)
-            parent_labels = [label["name"] for label in parent_issue.get("labels", [])]
+            try:
+                parent_issue = await gh_client.get_issue(state.epic_parent)
+            except GitHubApiError as exc:
+                console.print(f"[yellow]Warning:[/yellow] Could not check parent epic #{state.epic_parent}: {exc.message}")
+                console.print("Proceeding anyway — run agentharness status to check epic state.")
+                # Don't block — proceed to enqueue_planner
+            else:
+                parent_labels = [label["name"] for label in parent_issue.get("labels", [])]
 
-            if EPIC_PAUSED in parent_labels:
-                console.print("[red]Epic is paused[/red] — a child feature has failed.")
-                console.print(f"Parent epic: #{state.epic_parent}")
-                console.print(
-                    "To retry: fix the failing child's brief, remove the epic:paused label from "
-                    f"#{state.epic_parent}, then re-run this command."
-                )
-                raise SystemExit(1)
+                if EPIC_PAUSED in parent_labels:
+                    console.print("[red]Epic is paused[/red] — a child feature has failed.")
+                    console.print(f"Parent epic: #{state.epic_parent}")
+                    console.print(
+                        "To retry: fix the failing child's brief, remove the epic:paused label from "
+                        f"#{state.epic_parent}, then re-run this command."
+                    )
+                    raise SystemExit(1)
 
         # Non-epic or parent is not paused — proceed
         await enqueue_planner(feature_id, config)
-        console.print(f"[green]Pipeline started:[/green] {feature_id}")
-        console.print(f"Monitor: [bold]agentharness watch[/bold]")
+        _print_started(feature_id)
 
     finally:
         await gh_client.close()

--- a/agentharness/cli.py
+++ b/agentharness/cli.py
@@ -73,6 +73,7 @@ async def _implement_with_epic_check(feature_id: str, config) -> None:
 
     finally:
         await gh_client.close()
+        await state_mgr.close()
 
 
 @click.group()

--- a/agentharness/dispatcher.py
+++ b/agentharness/dispatcher.py
@@ -88,7 +88,12 @@ async def run_terminal_cleanup(state: FeatureState, state_manager) -> None:
             if isinstance(state_manager, GitHubStateManager):
                 await state_manager.handle_epic_child_failed(
                     state,
-                    reason=f"Feature {state.feature_id} reached failed status"
+                    reason=f"Feature {state.feature_id} reached failed status",
+                )
+            else:
+                log.warning(
+                    "Epic pause label only supported on GitHub backend; skipping for %s",
+                    state.feature_id,
                 )
 
 
@@ -898,6 +903,11 @@ async def _open_feature_pr(
         from agentharness.github_state import GitHubStateManager
         if isinstance(state_mgr, GitHubStateManager):
             await state_mgr.handle_epic_child_done(state)
+        else:
+            log.warning(
+                "Epic PR lifecycle only supported on GitHub backend; skipping for %s",
+                state.feature_id,
+            )
         return
 
     # Non-epic: existing behavior

--- a/agentharness/dispatcher.py
+++ b/agentharness/dispatcher.py
@@ -40,34 +40,56 @@ async def run_terminal_cleanup(state: FeatureState, state_manager) -> None:
         return
 
     if state.status == FeatureStatus.done:
-        log.info(
-            "Worktree removal started for %s at %s",
-            state.feature_id, state.worktree_path,
+        # Non-last epic child: skip worktree removal so next sibling can reuse the branch
+        is_non_last_epic_child = (
+            state.epic_parent is not None
+            and state.epic_total is not None
+            and state.epic_position is not None
+            and state.epic_position < state.epic_total
         )
-        try:
-            await asyncio.to_thread(remove_worktree, state.worktree_path)
+        if is_non_last_epic_child:
             log.info(
-                "Worktree removal succeeded for %s at %s",
+                "Skipping worktree removal for epic child %s (position %d/%d) — "
+                "next sibling will reuse branch",
+                state.feature_id, state.epic_position, state.epic_total,
+            )
+        else:
+            log.info(
+                "Worktree removal started for %s at %s",
                 state.feature_id, state.worktree_path,
             )
-        except WorktreeRemovalError as exc:
-            log.error(
-                "Worktree removal failed for %s at %s: %s",
-                state.feature_id, state.worktree_path, exc,
-            )
             try:
-                await state_manager.set_cleanup_warning(state.feature_id, str(exc))
-            except Exception as warn_exc:
-                log.error(
-                    "Failed to persist cleanup_warning for %s: %s",
-                    state.feature_id, warn_exc,
+                await asyncio.to_thread(remove_worktree, state.worktree_path)
+                log.info(
+                    "Worktree removal succeeded for %s at %s",
+                    state.feature_id, state.worktree_path,
                 )
+            except WorktreeRemovalError as exc:
+                log.error(
+                    "Worktree removal failed for %s at %s: %s",
+                    state.feature_id, state.worktree_path, exc,
+                )
+                try:
+                    await state_manager.set_cleanup_warning(state.feature_id, str(exc))
+                except Exception as warn_exc:
+                    log.error(
+                        "Failed to persist cleanup_warning for %s: %s",
+                        state.feature_id, warn_exc,
+                    )
 
     elif state.status == FeatureStatus.failed:
         log.info(
             "Preserving worktree at %s for inspection (feature %s failed)",
             state.worktree_path, state.feature_id,
         )
+        # Epic child failure: apply pause label + post comment
+        if state.epic_parent is not None:
+            from agentharness.github_state import GitHubStateManager
+            if isinstance(state_manager, GitHubStateManager):
+                await state_manager.handle_epic_child_failed(
+                    state,
+                    reason=f"Feature {state.feature_id} reached failed status"
+                )
 
 
 # Maps feature status → (next_status, next_queue_key)
@@ -870,6 +892,15 @@ async def _open_feature_pr(
     """Open a GitHub PR for the completed feature via the state backend abstraction."""
     if state_mgr is None:
         return
+
+    # Epic children: delegate to epic PR handler instead of opening a regular PR
+    if state.epic_parent is not None:
+        from agentharness.github_state import GitHubStateManager
+        if isinstance(state_mgr, GitHubStateManager):
+            await state_mgr.handle_epic_child_done(state)
+        return
+
+    # Non-epic: existing behavior
     pr_title, pr_summary = await _build_pr_content(state, store)
     await state_mgr.open_review(
         state.feature_id,

--- a/agentharness/github_artifacts.py
+++ b/agentharness/github_artifacts.py
@@ -164,11 +164,26 @@ class GitHubArtifactStore:
     # ------------------------------------------------------------------
 
     async def _checkout_or_create(self, branch_name: str) -> None:
-        """Checkout *branch_name* if it exists locally/remotely, else create it."""
+        """Checkout *branch_name* if it exists locally/remotely, else create it.
+
+        Three-tier fallback:
+        1. Checkout existing local branch (fast path).
+        2. Create local tracking branch from remote (epic children 2..N where the
+           branch already exists on remote but not locally).
+        3. Create fresh local branch (brand-new branch, no remote copy yet).
+        """
         try:
             await _run_git("-C", str(self._clone_root), "checkout", branch_name)
         except RuntimeError:
-            await _run_git("-C", str(self._clone_root), "checkout", "-b", branch_name)
+            try:
+                # Branch exists on remote but not locally — create local tracking branch
+                await _run_git(
+                    "-C", str(self._clone_root),
+                    "checkout", "-b", branch_name, f"origin/{branch_name}",
+                )
+            except RuntimeError:
+                # Branch doesn't exist anywhere — create fresh local branch
+                await _run_git("-C", str(self._clone_root), "checkout", "-b", branch_name)
 
     async def upload(self, path: str, content: str | bytes) -> None:
         """Write *content* to *path* on the feature branch and push."""

--- a/agentharness/github_client.py
+++ b/agentharness/github_client.py
@@ -197,6 +197,34 @@ class GitHubClient:
             json={"sub_issue_id": child_number},
         )
 
+    async def list_sub_issues(self, parent_number: int) -> list[dict]:
+        """Return the list of sub-issues for *parent_number*.
+
+        Uses the GitHub sub-issues beta API.  Returns an empty list when the
+        parent has no sub-issues or the endpoint returns an empty array.
+        """
+        result: list[dict] = await self._request(  # type: ignore[assignment]
+            "GET",
+            self._repo_url(f"/issues/{parent_number}/sub_issues"),
+        )
+        return result if result else []
+
+    async def get_parent_issue(self, child_number: int) -> dict | None:
+        """Return the parent issue dict if *child_number* is a sub-issue.
+
+        GitHub's REST API (as of the sub-issues beta) exposes the parent
+        relationship via a ``parent_issue`` field on the issue response when
+        the issue was created as a sub-issue.  If the field is absent or
+        ``None`` the issue is a standalone issue and ``None`` is returned.
+
+        Note: ``parent_issue`` is part of the GitHub sub-issues *beta* and
+        may not be present for all issues or all API versions.  This is a
+        best-effort implementation; callers should handle ``None`` gracefully.
+        """
+        issue = await self._request("GET", self._repo_url(f"/issues/{child_number}"))
+        parent: dict | None = issue.get("parent_issue")
+        return parent if parent else None
+
     # ------------------------------------------------------------------
     # Refs / branches
     # ------------------------------------------------------------------
@@ -304,11 +332,15 @@ class GitHubClient:
         head: str,
         base: str,
         labels: list[str] | None = None,
+        draft: bool = False,
     ) -> dict:
+        payload: dict = {"title": title, "body": body, "head": head, "base": base}
+        if draft:
+            payload["draft"] = True
         pr = await self._request(
             "POST",
             self._repo_url("/pulls"),
-            json={"title": title, "body": body, "head": head, "base": base},
+            json=payload,
         )
         if labels:
             number = pr["number"]
@@ -328,3 +360,30 @@ class GitHubClient:
                 )
                 raise
         return pr
+
+    async def update_pull_request(
+        self,
+        number: int,
+        *,
+        body: str | None = None,
+        draft: bool | None = None,
+    ) -> dict:
+        """PATCH /repos/{owner}/{repo}/pulls/{number}.
+
+        Only fields that are not ``None`` are included in the request payload.
+        Returns the updated PR dict.
+        """
+        payload: dict = {}
+        if body is not None:
+            payload["body"] = body
+        if draft is not None:
+            payload["draft"] = draft
+        return await self._request(
+            "PATCH",
+            self._repo_url(f"/pulls/{number}"),
+            json=payload,
+        )
+
+    async def mark_pr_ready(self, number: int) -> dict:
+        """Convert a draft PR to ready-for-review."""
+        return await self.update_pull_request(number, draft=False)

--- a/agentharness/github_client.py
+++ b/agentharness/github_client.py
@@ -330,6 +330,18 @@ class GitHubClient:
     # Pull requests
     # ------------------------------------------------------------------
 
+    async def list_pull_requests(
+        self, *, head: str | None = None, state: str = "open"
+    ) -> list[dict]:
+        """List PRs, optionally filtering by head branch."""
+        params: dict = {"state": state, "per_page": 100}
+        if head is not None:
+            params["head"] = f"{self.owner}:{head}"
+        result: list[dict] = await self._request(  # type: ignore[assignment]
+            "GET", self._repo_url("/pulls"), params=params
+        )
+        return result
+
     async def create_pull_request(
         self,
         title: str,

--- a/agentharness/github_client.py
+++ b/agentharness/github_client.py
@@ -202,12 +202,17 @@ class GitHubClient:
 
         Uses the GitHub sub-issues beta API.  Returns an empty list when the
         parent has no sub-issues or the endpoint returns an empty array.
+
+        Note: fetches up to 100 sub-issues per request (no pagination).
+        Epics with more than 100 sub-issues are not realistically expected,
+        so a single page is sufficient.
         """
         result: list[dict] = await self._request(  # type: ignore[assignment]
             "GET",
             self._repo_url(f"/issues/{parent_number}/sub_issues"),
+            params={"per_page": 100},
         )
-        return result if result else []
+        return result or []
 
     async def get_parent_issue(self, child_number: int) -> dict | None:
         """Return the parent issue dict if *child_number* is a sub-issue.
@@ -378,6 +383,8 @@ class GitHubClient:
             payload["body"] = body
         if draft is not None:
             payload["draft"] = draft
+        if not payload:
+            raise ValueError("update_pull_request requires at least one field: body or draft")
         return await self._request(
             "PATCH",
             self._repo_url(f"/pulls/{number}"),

--- a/agentharness/github_client.py
+++ b/agentharness/github_client.py
@@ -331,16 +331,28 @@ class GitHubClient:
     # ------------------------------------------------------------------
 
     async def list_pull_requests(
-        self, *, head: str | None = None, state: str = "open"
+        self,
+        *,
+        head: str | None = None,
+        state: str = "open",
+        per_page: int = 100,
     ) -> list[dict]:
         """List PRs, optionally filtering by head branch."""
-        params: dict = {"state": state, "per_page": 100}
+        params: dict = {"state": state, "per_page": per_page}
         if head is not None:
             params["head"] = f"{self.owner}:{head}"
-        result: list[dict] = await self._request(  # type: ignore[assignment]
-            "GET", self._repo_url("/pulls"), params=params
-        )
-        return result
+        all_results: list[dict] = []
+        page = 1
+        while True:
+            params["page"] = page
+            page_results: list[dict] = await self._request(  # type: ignore[assignment]
+                "GET", self._repo_url("/pulls"), params=params
+            )
+            all_results.extend(page_results)
+            if len(page_results) < per_page:
+                break
+            page += 1
+        return all_results
 
     async def create_pull_request(
         self,

--- a/agentharness/github_labels.py
+++ b/agentharness/github_labels.py
@@ -90,6 +90,12 @@ IMPLEMENT_LABEL = "implement"
 
 CLAIMED_BY_PREFIX = "claimed-by:"
 
+# ---------------------------------------------------------------------------
+# Epic labels
+# ---------------------------------------------------------------------------
+
+EPIC_PAUSED = "epic:paused"
+
 
 def claimed_by_label(worker_id: str) -> str:
     """Return the claim label for a given worker ID."""

--- a/agentharness/github_state.py
+++ b/agentharness/github_state.py
@@ -176,6 +176,11 @@ def _synthesize_raw_state(issue: dict) -> FeatureState:
 # ---------------------------------------------------------------------------
 
 
+def _tick_epic_pr_checkbox(body: str, issue_number: int) -> str:
+    """Replace '- [ ] #N ...' with '- [x] #N ...' for the given issue number."""
+    return re.sub(rf"- \[ \] #{issue_number}\b", f"- [x] #{issue_number}", body)
+
+
 class GitHubStateManager:
     """StateBackend implementation backed by GitHub Issues."""
 
@@ -446,6 +451,84 @@ class GitHubStateManager:
                 )
                 states.append(_synthesize_raw_state(issue))
         return states
+
+    async def handle_epic_child_done(self, state: FeatureState) -> None:
+        """Open/update/mark-ready the shared epic PR when an epic child completes."""
+        if state.epic_parent is None or state.epic_branch is None:
+            return
+
+        # Find existing epic PR by branch
+        prs = await self._client.list_pull_requests(head=state.epic_branch)
+        open_pr = next((pr for pr in prs if pr.get("state") == "open"), None)
+
+        if open_pr is None:
+            # First child: open draft PR
+            parent = await self._client.get_issue(state.epic_parent)
+            sub_issues = await self._client.list_sub_issues(state.epic_parent)
+
+            # Build PR title from parent epic title
+            pr_title = f"{parent.get('title', state.epic_branch)}"
+
+            # Build body: checklist of all child issues
+            checklist_items = "\n".join(
+                f"- [ ] #{si['number']} {si.get('title', '')}" for si in sub_issues
+            )
+            pr_body = f"## Epic\n\nPart of #{state.epic_parent}\n\n### Tasks\n\n{checklist_items}"
+
+            default_branch = await self._client.get_default_branch()
+            pr = await self._client.create_pull_request(
+                title=pr_title,
+                body=pr_body,
+                head=state.epic_branch,
+                base=default_branch,
+                draft=True,
+            )
+            log.info("Opened draft epic PR #%s for %s", pr.get("number"), state.feature_id)
+            open_pr = pr
+        else:
+            # Subsequent children: tick the checkbox for this child's issue number
+            child_issue_number = state.state_issue_number
+            if child_issue_number is not None:
+                current_body = open_pr.get("body") or ""
+                updated_body = _tick_epic_pr_checkbox(current_body, child_issue_number)
+                if updated_body != current_body:
+                    await self._client.update_pull_request(open_pr["number"], body=updated_body)
+
+        # If this is the last child, mark the PR ready for review
+        if (
+            state.epic_total is not None
+            and state.epic_position is not None
+            and state.epic_position >= state.epic_total
+        ):
+            await self._client.mark_pr_ready(open_pr["number"])
+            log.info("Marked epic PR #%s ready", open_pr["number"])
+
+    async def handle_epic_child_failed(
+        self, state: FeatureState, reason: str = "unknown"
+    ) -> None:
+        """Apply EPIC_PAUSED label to parent epic + post comment on failing child."""
+        if state.epic_parent is None:
+            return
+        from agentharness.github_labels import EPIC_PAUSED
+
+        try:
+            await self._client.add_labels(state.epic_parent, [EPIC_PAUSED])
+            log.info("Applied %s to epic issue #%s", EPIC_PAUSED, state.epic_parent)
+        except Exception as exc:
+            log.error("Failed to apply %s to epic #%s: %s", EPIC_PAUSED, state.epic_parent, exc)
+
+        if state.state_issue_number is not None:
+            comment = (
+                f"⚠️ **Epic paused**: this feature failed.\n\n"
+                f"**Reason**: {reason}\n\n"
+                f"To retry: edit this issue's brief to clarify, then remove the "
+                f"`epic:paused` label from the parent epic issue #{state.epic_parent}, "
+                f"and re-run:\n```\nagentharness implement {state.feature_id}\n```"
+            )
+            try:
+                await self._client.create_comment(state.state_issue_number, comment)
+            except Exception as exc:
+                log.error("Failed to post failure comment on #%s: %s", state.state_issue_number, exc)
 
     async def close(self) -> None:
         """Close the underlying HTTP connection pool."""

--- a/agentharness/github_state.py
+++ b/agentharness/github_state.py
@@ -17,6 +17,7 @@ import re
 from typing import TYPE_CHECKING, Callable
 
 from agentharness.github_labels import (
+    EPIC_PAUSED,
     FEATURE_STATUS_TO_LABEL,
     FEAT_STATUS_LABELS,
     LABEL_TO_FEATURE_STATUS,
@@ -467,7 +468,7 @@ class GitHubStateManager:
             sub_issues = await self._client.list_sub_issues(state.epic_parent)
 
             # Build PR title from parent epic title
-            pr_title = f"{parent.get('title', state.epic_branch)}"
+            pr_title = parent.get("title") or state.epic_branch or state.feature_id
 
             # Build body: checklist of all child issues
             checklist_items = "\n".join(
@@ -485,6 +486,11 @@ class GitHubStateManager:
             )
             log.info("Opened draft epic PR #%s for %s", pr.get("number"), state.feature_id)
             open_pr = pr
+            # Tick the first child's own checkbox
+            if state.state_issue_number is not None:
+                updated_body = _tick_epic_pr_checkbox(open_pr.get("body") or "", state.state_issue_number)
+                if updated_body != (open_pr.get("body") or ""):
+                    await self._client.update_pull_request(open_pr["number"], body=updated_body)
         else:
             # Subsequent children: tick the checkbox for this child's issue number
             child_issue_number = state.state_issue_number
@@ -509,7 +515,6 @@ class GitHubStateManager:
         """Apply EPIC_PAUSED label to parent epic + post comment on failing child."""
         if state.epic_parent is None:
             return
-        from agentharness.github_labels import EPIC_PAUSED
 
         try:
             await self._client.add_labels(state.epic_parent, [EPIC_PAUSED])

--- a/agentharness/models.py
+++ b/agentharness/models.py
@@ -118,6 +118,7 @@ class FeatureState(BaseModel):
     epic_parent: int | None = None
     epic_position: int | None = None
     epic_branch: str | None = None
+    epic_total: int | None = None
 
     def with_event(self, event: str, **kwargs: Any) -> FeatureState:
         """Return new state with appended history event (immutable update)."""

--- a/agentharness/models.py
+++ b/agentharness/models.py
@@ -115,6 +115,9 @@ class FeatureState(BaseModel):
     state_issue_number: int | None = None
     pr_number: int | None = None
     pr_url: str | None = None
+    epic_parent: int | None = None
+    epic_position: int | None = None
+    epic_branch: str | None = None
 
     def with_event(self, event: str, **kwargs: Any) -> FeatureState:
         """Return new state with appended history event (immutable update)."""

--- a/tests/test_brainstorm_github.py
+++ b/tests/test_brainstorm_github.py
@@ -723,8 +723,10 @@ class TestConvertRawIssueEpic:
             # Must not raise
             await _convert_raw_issue("feat-task-two", config)
 
-        # Branch creation skipped for child 2
+        # Branch creation skipped for child 2, so get_default_branch and get_ref not called
         gh_client.create_ref.assert_not_awaited()
+        gh_client.get_default_branch.assert_not_awaited()
+        gh_client.get_ref.assert_not_awaited()
 
         # State has correct epic fields, branch_name is epic_branch
         patched_state = state_mgr.patch_existing_issue.call_args.args[1]
@@ -764,6 +766,8 @@ class TestConvertRawIssueEpic:
             with pytest.raises(ValueError, match="not done"):
                 await _convert_raw_issue("feat-task-two", config)
 
-        # Branch creation skipped, and patch_existing_issue never called
+        # Branch creation skipped, so get_default_branch and get_ref not called
         gh_client.create_ref.assert_not_awaited()
+        gh_client.get_default_branch.assert_not_awaited()
+        gh_client.get_ref.assert_not_awaited()
         state_mgr.patch_existing_issue.assert_not_awaited()

--- a/tests/test_brainstorm_github.py
+++ b/tests/test_brainstorm_github.py
@@ -305,6 +305,7 @@ class TestConvertRawIssue:
         gh_client.list_issues.return_value = [
             TestConvertRawIssue._raw_issue(number=7, title="Add Export Endpoint")
         ]
+        gh_client.get_parent_issue.return_value = None
         gh_client.get_default_branch.return_value = "main"
         gh_client.get_ref.return_value = {"object": {"sha": "abc123"}}
         gh_client.create_ref = AsyncMock(return_value={"ref": "refs/heads/feat-add-export-endpoint"})
@@ -358,6 +359,7 @@ class TestConvertRawIssue:
         gh_client.list_issues.return_value = [
             TestConvertRawIssue._raw_issue(number=7, title="Already Exists")
         ]
+        gh_client.get_parent_issue.return_value = None
         gh_client.get_default_branch.return_value = "main"
         gh_client.get_ref.return_value = {"object": {"sha": "abc123"}}
         gh_client.create_ref.side_effect = GitHubApiError(422, "Reference already exists")
@@ -409,6 +411,7 @@ class TestConvertRawIssue:
         gh_client.list_issues.return_value = [
             TestConvertRawIssue._raw_issue(number=7, title="Boom Title")
         ]
+        gh_client.get_parent_issue.return_value = None
         gh_client.get_default_branch.return_value = "main"
         gh_client.get_ref.return_value = {"object": {"sha": "abc123"}}
         gh_client.create_ref = AsyncMock(return_value={})
@@ -550,3 +553,217 @@ class TestEnqueuePlannerPreflight:
 
         convert.assert_awaited_once()
         queue.send_task.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _convert_raw_issue — epic branch parameterisation
+# ---------------------------------------------------------------------------
+
+
+class TestConvertRawIssueEpic:
+    """Tests for epic-child branch logic in _convert_raw_issue."""
+
+    @staticmethod
+    def _raw_issue(*, number: int, title: str, body: str = "Issue body.") -> dict:
+        return {
+            "number": number,
+            "title": title,
+            "body": body,
+            "created_at": "2026-04-30T10:00:00Z",
+            "updated_at": "2026-04-30T10:00:00Z",
+            "labels": [{"name": "agent"}],
+        }
+
+    @staticmethod
+    def _make_gh_client(
+        *,
+        issue_number: int = 10,
+        issue_title: str = "My Feature",
+        parent_issue: dict | None = None,
+        sub_issues: list[dict] | None = None,
+    ) -> AsyncMock:
+        gh_client = AsyncMock()
+        gh_client.list_issues.return_value = [
+            TestConvertRawIssueEpic._raw_issue(number=issue_number, title=issue_title)
+        ]
+        gh_client.get_parent_issue.return_value = parent_issue
+        gh_client.list_sub_issues.return_value = sub_issues or []
+        gh_client.get_default_branch.return_value = "main"
+        gh_client.get_ref.return_value = {"object": {"sha": "deadbeef"}}
+        gh_client.create_ref = AsyncMock(return_value={})
+        gh_client.close = AsyncMock()
+        return gh_client
+
+    @staticmethod
+    def _make_state_mgr_for_epic(*, prev_status: str | None = None) -> MagicMock:
+        from agentharness.models import FeatureState, FeatureStatus
+
+        state_mgr = MagicMock()
+        state_mgr.patch_existing_issue = AsyncMock()
+        state_mgr.close = AsyncMock()
+        if prev_status is not None:
+            prev_state = FeatureState(
+                feature_id="feat-task-one",
+                status=FeatureStatus(prev_status),
+            )
+            state_mgr.get = AsyncMock(return_value=prev_state)
+        else:
+            state_mgr.get = AsyncMock(side_effect=KeyError("not found"))
+        return state_mgr
+
+    @pytest.mark.asyncio
+    async def test_convert_raw_issue_non_epic(self):
+        """Non-epic issue: branch is feature_id, no epic fields on state."""
+        from agentharness.brainstorm import _convert_raw_issue
+        from agentharness.models import FeatureStatus
+
+        config = _make_config()
+        config.github.feature_marker = "agent"
+
+        gh_client = self._make_gh_client(
+            issue_number=10,
+            issue_title="My Feature",
+            parent_issue=None,  # no parent — standalone issue
+        )
+        store = _make_store()
+        state_mgr = self._make_state_mgr_for_epic()
+
+        with (
+            patch("agentharness.brainstorm.GitHubClient.from_config", return_value=gh_client),
+            patch("agentharness.brainstorm.create_artifact_store", return_value=store),
+            patch("agentharness.brainstorm.create_state_manager", return_value=state_mgr),
+        ):
+            await _convert_raw_issue("feat-my-feature", config)
+
+        # Branch created as feature_id, not an epic branch
+        gh_client.create_ref.assert_awaited_once()
+        ref_arg = gh_client.create_ref.call_args.args[0]
+        assert ref_arg == "refs/heads/feat-my-feature"
+
+        # State has no epic fields
+        patched_state = state_mgr.patch_existing_issue.call_args.args[1]
+        assert patched_state.branch_name == "feat-my-feature"
+        assert patched_state.epic_parent is None
+        assert patched_state.epic_position is None
+        assert patched_state.epic_branch is None
+        assert patched_state.status == FeatureStatus.brainstormed
+
+    @pytest.mark.asyncio
+    async def test_convert_raw_issue_epic_child_1(self):
+        """First epic child: branch created as epic_branch, state has epic fields."""
+        from agentharness.brainstorm import _convert_raw_issue
+        from agentharness.models import FeatureStatus
+
+        config = _make_config()
+        config.github.feature_marker = "agent"
+
+        parent = {"number": 1, "title": "My Epic", "body": "Epic body."}
+        # Two sub-issues; this feature is the first
+        sub_issues = [
+            {"number": 10, "title": "Task One"},
+            {"number": 11, "title": "Task Two"},
+        ]
+        gh_client = self._make_gh_client(
+            issue_number=10,
+            issue_title="Task One",
+            parent_issue=parent,
+            sub_issues=sub_issues,
+        )
+        store = _make_store()
+        state_mgr = self._make_state_mgr_for_epic()
+
+        with (
+            patch("agentharness.brainstorm.GitHubClient.from_config", return_value=gh_client),
+            patch("agentharness.brainstorm.create_artifact_store", return_value=store),
+            patch("agentharness.brainstorm.create_state_manager", return_value=state_mgr),
+        ):
+            await _convert_raw_issue("feat-task-one", config)
+
+        # Branch created as epic_branch
+        gh_client.create_ref.assert_awaited_once()
+        ref_arg = gh_client.create_ref.call_args.args[0]
+        assert ref_arg == "refs/heads/epic-my-epic"
+
+        # State has correct epic fields
+        patched_state = state_mgr.patch_existing_issue.call_args.args[1]
+        assert patched_state.branch_name == "epic-my-epic"
+        assert patched_state.epic_parent == 1
+        assert patched_state.epic_position == 1
+        assert patched_state.epic_branch == "epic-my-epic"
+        assert patched_state.status == FeatureStatus.brainstormed
+
+    @pytest.mark.asyncio
+    async def test_convert_raw_issue_epic_child_2_prev_done(self):
+        """Second epic child when previous sibling is done: skips branch creation, proceeds."""
+        from agentharness.brainstorm import _convert_raw_issue
+
+        config = _make_config()
+        config.github.feature_marker = "agent"
+
+        parent = {"number": 1, "title": "My Epic", "body": "Epic body."}
+        sub_issues = [
+            {"number": 10, "title": "Task One"},
+            {"number": 11, "title": "Task Two"},
+        ]
+        gh_client = self._make_gh_client(
+            issue_number=11,
+            issue_title="Task Two",
+            parent_issue=parent,
+            sub_issues=sub_issues,
+        )
+        store = _make_store()
+        # Previous sibling (feat-task-one) is done
+        state_mgr = self._make_state_mgr_for_epic(prev_status="done")
+
+        with (
+            patch("agentharness.brainstorm.GitHubClient.from_config", return_value=gh_client),
+            patch("agentharness.brainstorm.create_artifact_store", return_value=store),
+            patch("agentharness.brainstorm.create_state_manager", return_value=state_mgr),
+        ):
+            # Must not raise
+            await _convert_raw_issue("feat-task-two", config)
+
+        # Branch creation skipped for child 2
+        gh_client.create_ref.assert_not_awaited()
+
+        # State has correct epic fields, branch_name is epic_branch
+        patched_state = state_mgr.patch_existing_issue.call_args.args[1]
+        assert patched_state.branch_name == "epic-my-epic"
+        assert patched_state.epic_parent == 1
+        assert patched_state.epic_position == 2
+        assert patched_state.epic_branch == "epic-my-epic"
+
+    @pytest.mark.asyncio
+    async def test_convert_raw_issue_epic_child_2_prev_not_done(self):
+        """Second epic child when previous sibling is not done: raises ValueError."""
+        from agentharness.brainstorm import _convert_raw_issue
+
+        config = _make_config()
+        config.github.feature_marker = "agent"
+
+        parent = {"number": 1, "title": "My Epic", "body": "Epic body."}
+        sub_issues = [
+            {"number": 10, "title": "Task One"},
+            {"number": 11, "title": "Task Two"},
+        ]
+        gh_client = self._make_gh_client(
+            issue_number=11,
+            issue_title="Task Two",
+            parent_issue=parent,
+            sub_issues=sub_issues,
+        )
+        store = _make_store()
+        # Previous sibling (feat-task-one) is still developing — not done
+        state_mgr = self._make_state_mgr_for_epic(prev_status="developing")
+
+        with (
+            patch("agentharness.brainstorm.GitHubClient.from_config", return_value=gh_client),
+            patch("agentharness.brainstorm.create_artifact_store", return_value=store),
+            patch("agentharness.brainstorm.create_state_manager", return_value=state_mgr),
+        ):
+            with pytest.raises(ValueError, match="not done"):
+                await _convert_raw_issue("feat-task-two", config)
+
+        # Branch creation skipped, and patch_existing_issue never called
+        gh_client.create_ref.assert_not_awaited()
+        state_mgr.patch_existing_issue.assert_not_awaited()

--- a/tests/test_cli_epic_gating.py
+++ b/tests/test_cli_epic_gating.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agentharness.cli import _implement_with_epic_check
+from agentharness.github_client import GitHubApiError
 
 
 @pytest.mark.asyncio
@@ -175,4 +176,46 @@ async def test_implement_epic_not_paused_proceeds() -> None:
     # Should proceed normally
     mock_gh_client.get_issue.assert_called_once_with(5)
     mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
+    mock_gh_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_implement_epic_parent_api_error_proceeds() -> None:
+    """get_issue() raises GitHubApiError: warning printed, enqueue_planner IS called (proceeds despite error)."""
+    config = MagicMock()
+    config.storage_backend = "github"
+
+    # Create mock state with epic parent
+    mock_state = MagicMock()
+    mock_state.epic_parent = 5
+
+    mock_state_mgr = MagicMock()
+    mock_state_mgr.get = AsyncMock(return_value=mock_state)
+
+    # Mock GitHub client that raises GitHubApiError on get_issue
+    api_error = GitHubApiError(404, "Issue not found")
+    mock_gh_client = MagicMock()
+    mock_gh_client.get_issue = AsyncMock(side_effect=api_error)
+    mock_gh_client.close = AsyncMock()
+
+    mock_enqueue_planner = AsyncMock()
+    mock_console_print = MagicMock()
+
+    with patch("agentharness.cli.create_state_manager", return_value=mock_state_mgr):
+        with patch("agentharness.cli.GitHubClient.from_config", return_value=mock_gh_client):
+            with patch("agentharness.cli.enqueue_planner", mock_enqueue_planner):
+                with patch("agentharness.cli.console.print", mock_console_print):
+                    await _implement_with_epic_check("feat-test-123", config)
+
+    # Should print warning
+    calls = [str(call) for call in mock_console_print.call_args_list]
+    output = " ".join(calls)
+    assert "Warning" in output
+    assert "Could not check parent epic" in output
+    assert "Proceeding anyway" in output
+
+    # Should STILL call enqueue_planner (doesn't block)
+    mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
+
+    # Should have closed client
     mock_gh_client.close.assert_called_once()

--- a/tests/test_cli_epic_gating.py
+++ b/tests/test_cli_epic_gating.py
@@ -36,6 +36,7 @@ async def test_implement_no_existing_state_proceeds() -> None:
     # Mock state manager that raises KeyError
     mock_state_mgr = MagicMock()
     mock_state_mgr.get = AsyncMock(side_effect=KeyError("not found"))
+    mock_state_mgr.close = AsyncMock()
 
     # Mock GitHub client
     mock_gh_client = MagicMock()
@@ -54,6 +55,7 @@ async def test_implement_no_existing_state_proceeds() -> None:
     mock_state_mgr.get.assert_called_once_with("feat-test-123")
     mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
     mock_gh_client.close.assert_called_once()
+    mock_state_mgr.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -68,6 +70,7 @@ async def test_implement_non_epic_feature_proceeds() -> None:
 
     mock_state_mgr = MagicMock()
     mock_state_mgr.get = AsyncMock(return_value=mock_state)
+    mock_state_mgr.close = AsyncMock()
 
     mock_gh_client = MagicMock()
     mock_gh_client.close = AsyncMock()
@@ -87,6 +90,7 @@ async def test_implement_non_epic_feature_proceeds() -> None:
     mock_gh_client.get_issue.assert_not_called()
     mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
     mock_gh_client.close.assert_called_once()
+    mock_state_mgr.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -101,6 +105,7 @@ async def test_implement_epic_paused_exits() -> None:
 
     mock_state_mgr = MagicMock()
     mock_state_mgr.get = AsyncMock(return_value=mock_state)
+    mock_state_mgr.close = AsyncMock()
 
     # Mock parent issue with epic:paused label
     parent_issue = {
@@ -135,8 +140,9 @@ async def test_implement_epic_paused_exits() -> None:
     # Should NOT have called enqueue_planner
     mock_enqueue_planner.assert_not_called()
 
-    # Should have closed client
+    # Should have closed both client and state_mgr
     mock_gh_client.close.assert_called_once()
+    mock_state_mgr.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -151,6 +157,7 @@ async def test_implement_epic_not_paused_proceeds() -> None:
 
     mock_state_mgr = MagicMock()
     mock_state_mgr.get = AsyncMock(return_value=mock_state)
+    mock_state_mgr.close = AsyncMock()
 
     # Mock parent issue WITHOUT epic:paused label
     parent_issue = {
@@ -177,6 +184,7 @@ async def test_implement_epic_not_paused_proceeds() -> None:
     mock_gh_client.get_issue.assert_called_once_with(5)
     mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
     mock_gh_client.close.assert_called_once()
+    mock_state_mgr.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -191,6 +199,7 @@ async def test_implement_epic_parent_api_error_proceeds() -> None:
 
     mock_state_mgr = MagicMock()
     mock_state_mgr.get = AsyncMock(return_value=mock_state)
+    mock_state_mgr.close = AsyncMock()
 
     # Mock GitHub client that raises GitHubApiError on get_issue
     api_error = GitHubApiError(404, "Issue not found")
@@ -217,5 +226,6 @@ async def test_implement_epic_parent_api_error_proceeds() -> None:
     # Should STILL call enqueue_planner (doesn't block)
     mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
 
-    # Should have closed client
+    # Should have closed both client and state_mgr
     mock_gh_client.close.assert_called_once()
+    mock_state_mgr.close.assert_called_once()

--- a/tests/test_cli_epic_gating.py
+++ b/tests/test_cli_epic_gating.py
@@ -1,0 +1,178 @@
+"""Tests for CLI epic gating via _implement_with_epic_check function."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentharness.cli import _implement_with_epic_check
+
+
+@pytest.mark.asyncio
+async def test_implement_non_github_backend_skips_check() -> None:
+    """Non-GitHub backend: skips all checks and calls enqueue_planner."""
+    config = MagicMock()
+    config.storage_backend = "azure"
+
+    mock_enqueue_planner = AsyncMock()
+    mock_console_print = MagicMock()
+
+    with patch("agentharness.cli.enqueue_planner", mock_enqueue_planner):
+        with patch("agentharness.cli.console.print", mock_console_print):
+            await _implement_with_epic_check("feat-test-123", config)
+
+    # Should call enqueue_planner without touching state_mgr or gh_client
+    mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
+
+
+@pytest.mark.asyncio
+async def test_implement_no_existing_state_proceeds() -> None:
+    """KeyError from state_mgr.get: proceeds to enqueue_planner normally."""
+    config = MagicMock()
+    config.storage_backend = "github"
+
+    # Mock state manager that raises KeyError
+    mock_state_mgr = MagicMock()
+    mock_state_mgr.get = AsyncMock(side_effect=KeyError("not found"))
+
+    # Mock GitHub client
+    mock_gh_client = MagicMock()
+    mock_gh_client.close = AsyncMock()
+
+    mock_enqueue_planner = AsyncMock()
+    mock_console_print = MagicMock()
+
+    with patch("agentharness.cli.create_state_manager", return_value=mock_state_mgr):
+        with patch("agentharness.cli.GitHubClient.from_config", return_value=mock_gh_client):
+            with patch("agentharness.cli.enqueue_planner", mock_enqueue_planner):
+                with patch("agentharness.cli.console.print", mock_console_print):
+                    await _implement_with_epic_check("feat-test-123", config)
+
+    # Should try to get state, fail with KeyError, then proceed to enqueue
+    mock_state_mgr.get.assert_called_once_with("feat-test-123")
+    mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
+    mock_gh_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_implement_non_epic_feature_proceeds() -> None:
+    """State has epic_parent=None: proceeds normally without checking parent."""
+    config = MagicMock()
+    config.storage_backend = "github"
+
+    # Create mock state with no epic parent
+    mock_state = MagicMock()
+    mock_state.epic_parent = None
+
+    mock_state_mgr = MagicMock()
+    mock_state_mgr.get = AsyncMock(return_value=mock_state)
+
+    mock_gh_client = MagicMock()
+    mock_gh_client.close = AsyncMock()
+    mock_gh_client.get_issue = AsyncMock()
+
+    mock_enqueue_planner = AsyncMock()
+    mock_console_print = MagicMock()
+
+    with patch("agentharness.cli.create_state_manager", return_value=mock_state_mgr):
+        with patch("agentharness.cli.GitHubClient.from_config", return_value=mock_gh_client):
+            with patch("agentharness.cli.enqueue_planner", mock_enqueue_planner):
+                with patch("agentharness.cli.console.print", mock_console_print):
+                    await _implement_with_epic_check("feat-test-123", config)
+
+    # Should load state but NOT call get_issue (no epic parent)
+    mock_state_mgr.get.assert_called_once_with("feat-test-123")
+    mock_gh_client.get_issue.assert_not_called()
+    mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
+    mock_gh_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_implement_epic_paused_exits() -> None:
+    """State has epic_parent=5, parent has epic:paused label: exits with error."""
+    config = MagicMock()
+    config.storage_backend = "github"
+
+    # Create mock state with epic parent
+    mock_state = MagicMock()
+    mock_state.epic_parent = 5
+
+    mock_state_mgr = MagicMock()
+    mock_state_mgr.get = AsyncMock(return_value=mock_state)
+
+    # Mock parent issue with epic:paused label
+    parent_issue = {
+        "number": 5,
+        "labels": [
+            {"name": "epic:paused"},
+        ],
+    }
+
+    mock_gh_client = MagicMock()
+    mock_gh_client.get_issue = AsyncMock(return_value=parent_issue)
+    mock_gh_client.close = AsyncMock()
+
+    mock_enqueue_planner = AsyncMock()
+    mock_console_print = MagicMock()
+
+    with patch("agentharness.cli.create_state_manager", return_value=mock_state_mgr):
+        with patch("agentharness.cli.GitHubClient.from_config", return_value=mock_gh_client):
+            with patch("agentharness.cli.enqueue_planner", mock_enqueue_planner):
+                with patch("agentharness.cli.console.print", mock_console_print):
+                    with pytest.raises(SystemExit) as exc_info:
+                        await _implement_with_epic_check("feat-test-123", config)
+
+    # Should exit with code 1
+    assert exc_info.value.code == 1
+
+    # Should have printed error messages
+    calls = [str(call) for call in mock_console_print.call_args_list]
+    output = " ".join(calls)
+    assert "Epic is paused" in output
+
+    # Should NOT have called enqueue_planner
+    mock_enqueue_planner.assert_not_called()
+
+    # Should have closed client
+    mock_gh_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_implement_epic_not_paused_proceeds() -> None:
+    """State has epic_parent=5, parent has no epic:paused label: proceeds normally."""
+    config = MagicMock()
+    config.storage_backend = "github"
+
+    # Create mock state with epic parent
+    mock_state = MagicMock()
+    mock_state.epic_parent = 5
+
+    mock_state_mgr = MagicMock()
+    mock_state_mgr.get = AsyncMock(return_value=mock_state)
+
+    # Mock parent issue WITHOUT epic:paused label
+    parent_issue = {
+        "number": 5,
+        "labels": [
+            {"name": "epic"},
+        ],
+    }
+
+    mock_gh_client = MagicMock()
+    mock_gh_client.get_issue = AsyncMock(return_value=parent_issue)
+    mock_gh_client.close = AsyncMock()
+
+    mock_enqueue_planner = AsyncMock()
+    mock_console_print = MagicMock()
+
+    with patch("agentharness.cli.create_state_manager", return_value=mock_state_mgr):
+        with patch("agentharness.cli.GitHubClient.from_config", return_value=mock_gh_client):
+            with patch("agentharness.cli.enqueue_planner", mock_enqueue_planner):
+                with patch("agentharness.cli.console.print", mock_console_print):
+                    await _implement_with_epic_check("feat-test-123", config)
+
+    # Should proceed normally
+    mock_gh_client.get_issue.assert_called_once_with(5)
+    mock_enqueue_planner.assert_called_once_with("feat-test-123", config)
+    mock_gh_client.close.assert_called_once()

--- a/tests/test_epic_dispatch.py
+++ b/tests/test_epic_dispatch.py
@@ -1,0 +1,370 @@
+"""Tests for Task 5: epic dispatcher logic — worktree retention, draft PR lifecycle, pause-on-failure."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agentharness.dispatcher import run_terminal_cleanup, _open_feature_pr
+from agentharness.models import FeatureState, FeatureStatus
+
+
+def _make_epic_state(
+    *,
+    status: FeatureStatus = FeatureStatus.done,
+    epic_parent: int | None = 10,
+    epic_position: int | None = 1,
+    epic_total: int | None = 2,
+    worktree_path: str | None = "/tmp/wt/feat-x",
+    state_issue_number: int | None = 42,
+    epic_branch: str | None = "epic-my-epic",
+) -> FeatureState:
+    return FeatureState(
+        feature_id="feat-my-feature",
+        status=status,
+        worktree_path=worktree_path,
+        epic_parent=epic_parent,
+        epic_position=epic_position,
+        epic_total=epic_total,
+        epic_branch=epic_branch,
+        state_issue_number=state_issue_number,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5a. Worktree retention
+# ---------------------------------------------------------------------------
+
+class TestWorktreeRetention:
+    @pytest.mark.asyncio
+    async def test_non_last_epic_child_done_preserves_worktree(self):
+        """Non-last epic child (position < total): worktree should NOT be removed."""
+        state = _make_epic_state(
+            status=FeatureStatus.done,
+            epic_parent=10,
+            epic_position=1,
+            epic_total=2,
+        )
+        state_manager = MagicMock()
+
+        with patch("agentharness.dispatcher.remove_worktree") as mock_remove:
+            await run_terminal_cleanup(state, state_manager)
+
+        mock_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_last_epic_child_done_removes_worktree(self):
+        """Last epic child (position == total): worktree SHOULD be removed."""
+        state = _make_epic_state(
+            status=FeatureStatus.done,
+            epic_parent=10,
+            epic_position=2,
+            epic_total=2,
+        )
+        state_manager = MagicMock()
+        state_manager.set_cleanup_warning = AsyncMock()
+
+        with patch("agentharness.dispatcher.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            await run_terminal_cleanup(state, state_manager)
+
+        mock_thread.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_non_epic_done_removes_worktree(self):
+        """Non-epic feature: worktree should be removed normally on done."""
+        state = FeatureState(
+            feature_id="feat-normal",
+            status=FeatureStatus.done,
+            worktree_path="/tmp/wt/feat-normal",
+        )
+        state_manager = MagicMock()
+        state_manager.set_cleanup_warning = AsyncMock()
+
+        with patch("agentharness.dispatcher.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            await run_terminal_cleanup(state, state_manager)
+
+        mock_thread.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_epic_failed_applies_pause(self):
+        """Failed epic child triggers handle_epic_child_failed on GitHubStateManager."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = _make_epic_state(
+            status=FeatureStatus.failed,
+            epic_parent=10,
+            epic_position=1,
+            epic_total=2,
+        )
+
+        state_manager = MagicMock(spec=GitHubStateManager)
+        state_manager.handle_epic_child_failed = AsyncMock()
+
+        await run_terminal_cleanup(state, state_manager)
+
+        state_manager.handle_epic_child_failed.assert_called_once_with(
+            state,
+            reason="Feature feat-my-feature reached failed status",
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_epic_failed_does_not_call_pause(self):
+        """Failed non-epic feature does NOT call handle_epic_child_failed."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = FeatureState(
+            feature_id="feat-normal",
+            status=FeatureStatus.failed,
+            worktree_path="/tmp/wt/feat-normal",
+        )
+
+        state_manager = MagicMock(spec=GitHubStateManager)
+        state_manager.handle_epic_child_failed = AsyncMock()
+
+        await run_terminal_cleanup(state, state_manager)
+
+        state_manager.handle_epic_child_failed.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 5b. Eager draft PR lifecycle
+# ---------------------------------------------------------------------------
+
+class TestHandleEpicChildDone:
+    def _make_github_state_manager(self) -> MagicMock:
+        from agentharness.github_state import GitHubStateManager
+        mgr = MagicMock(spec=GitHubStateManager)
+        mgr._client = MagicMock()
+        return mgr
+
+    @pytest.mark.asyncio
+    async def test_opens_draft_pr_for_first_child(self):
+        """First epic child with no existing PR: draft PR should be opened with a checklist."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = _make_epic_state(
+            epic_position=1,
+            epic_total=2,
+            state_issue_number=42,
+        )
+
+        mgr = GitHubStateManager.__new__(GitHubStateManager)
+        mgr._client = MagicMock()
+        mgr._client.list_pull_requests = AsyncMock(return_value=[])
+        mgr._client.get_issue = AsyncMock(return_value={"title": "My Epic Feature", "number": 10})
+        mgr._client.list_sub_issues = AsyncMock(return_value=[
+            {"number": 42, "title": "Sub-task 1"},
+            {"number": 43, "title": "Sub-task 2"},
+        ])
+        mgr._client.get_default_branch = AsyncMock(return_value="main")
+        mgr._client.create_pull_request = AsyncMock(return_value={"number": 99, "state": "open"})
+        mgr._client.mark_pr_ready = AsyncMock()
+
+        await mgr.handle_epic_child_done(state)
+
+        mgr._client.create_pull_request.assert_called_once()
+        call_kwargs = mgr._client.create_pull_request.call_args
+        assert call_kwargs.kwargs.get("draft") is True
+        body = call_kwargs.kwargs.get("body", "")
+        assert "- [ ] #42" in body
+        assert "- [ ] #43" in body
+        # Not last child: should NOT mark ready
+        mgr._client.mark_pr_ready.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ticks_checkbox_for_subsequent_child(self):
+        """Subsequent child with existing open PR: checkbox ticked, PR not marked ready."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = _make_epic_state(
+            epic_position=1,
+            epic_total=2,
+            state_issue_number=42,
+        )
+
+        existing_pr = {
+            "number": 99,
+            "state": "open",
+            "body": "## Epic\n\nPart of #10\n\n### Tasks\n\n- [ ] #42 Sub-task 1\n- [ ] #43 Sub-task 2",
+        }
+
+        mgr = GitHubStateManager.__new__(GitHubStateManager)
+        mgr._client = MagicMock()
+        mgr._client.list_pull_requests = AsyncMock(return_value=[existing_pr])
+        mgr._client.update_pull_request = AsyncMock(return_value={})
+        mgr._client.mark_pr_ready = AsyncMock()
+
+        await mgr.handle_epic_child_done(state)
+
+        mgr._client.update_pull_request.assert_called_once()
+        updated_body = mgr._client.update_pull_request.call_args.kwargs.get("body", "")
+        assert "- [x] #42" in updated_body
+        assert "- [ ] #43" in updated_body
+        # Not last child: should NOT mark ready
+        mgr._client.mark_pr_ready.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_marks_pr_ready_for_last_child(self):
+        """Last epic child: PR should be marked ready for review after update."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = _make_epic_state(
+            epic_position=2,
+            epic_total=2,
+            state_issue_number=43,
+        )
+
+        existing_pr = {
+            "number": 99,
+            "state": "open",
+            "body": "## Epic\n\nPart of #10\n\n### Tasks\n\n- [x] #42 Sub-task 1\n- [ ] #43 Sub-task 2",
+        }
+
+        mgr = GitHubStateManager.__new__(GitHubStateManager)
+        mgr._client = MagicMock()
+        mgr._client.list_pull_requests = AsyncMock(return_value=[existing_pr])
+        mgr._client.update_pull_request = AsyncMock(return_value={})
+        mgr._client.mark_pr_ready = AsyncMock(return_value={})
+
+        await mgr.handle_epic_child_done(state)
+
+        mgr._client.mark_pr_ready.assert_called_once_with(99)
+
+    @pytest.mark.asyncio
+    async def test_returns_early_when_no_epic_parent(self):
+        """State with no epic_parent: handle_epic_child_done is a no-op."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = FeatureState(
+            feature_id="feat-standalone",
+            status=FeatureStatus.done,
+        )
+
+        mgr = GitHubStateManager.__new__(GitHubStateManager)
+        mgr._client = MagicMock()
+        mgr._client.list_pull_requests = AsyncMock()
+
+        await mgr.handle_epic_child_done(state)
+
+        mgr._client.list_pull_requests.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 5b. _open_feature_pr routing
+# ---------------------------------------------------------------------------
+
+class TestOpenFeaturePr:
+    @pytest.mark.asyncio
+    async def test_open_feature_pr_bypasses_regular_pr_for_epic(self):
+        """Epic child: open_review should NOT be called; handle_epic_child_done IS called."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = _make_epic_state(
+            status=FeatureStatus.done,
+            epic_parent=10,
+        )
+
+        state_mgr = MagicMock(spec=GitHubStateManager)
+        state_mgr.handle_epic_child_done = AsyncMock()
+        state_mgr.open_review = AsyncMock()
+
+        await _open_feature_pr(state, state_mgr)
+
+        state_mgr.handle_epic_child_done.assert_called_once_with(state)
+        state_mgr.open_review.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_feature_pr_calls_open_review_for_non_epic(self):
+        """Non-epic feature: open_review should be called normally."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = FeatureState(
+            feature_id="feat-normal",
+            status=FeatureStatus.done,
+        )
+
+        state_mgr = MagicMock(spec=GitHubStateManager)
+        state_mgr.open_review = AsyncMock()
+        state_mgr.handle_epic_child_done = AsyncMock()
+
+        with patch("agentharness.dispatcher._build_pr_content", new_callable=AsyncMock) as mock_build:
+            mock_build.return_value = ("PR Title", "PR Summary")
+            await _open_feature_pr(state, state_mgr)
+
+        state_mgr.open_review.assert_called_once()
+        state_mgr.handle_epic_child_done.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_feature_pr_returns_early_for_none_state_mgr(self):
+        """state_mgr=None: returns immediately without error."""
+        state = _make_epic_state()
+        # Should not raise
+        await _open_feature_pr(state, None)
+
+
+# ---------------------------------------------------------------------------
+# 5c. handle_epic_child_failed
+# ---------------------------------------------------------------------------
+
+class TestHandleEpicChildFailed:
+    @pytest.mark.asyncio
+    async def test_applies_pause_label_and_posts_comment(self):
+        """handle_epic_child_failed applies EPIC_PAUSED label and posts a comment."""
+        from agentharness.github_state import GitHubStateManager
+        from agentharness.github_labels import EPIC_PAUSED
+
+        state = _make_epic_state(
+            status=FeatureStatus.failed,
+            epic_parent=10,
+            state_issue_number=42,
+        )
+
+        mgr = GitHubStateManager.__new__(GitHubStateManager)
+        mgr._client = MagicMock()
+        mgr._client.add_labels = AsyncMock()
+        mgr._client.create_comment = AsyncMock()
+
+        await mgr.handle_epic_child_failed(state, reason="test failure")
+
+        mgr._client.add_labels.assert_called_once_with(10, [EPIC_PAUSED])
+        mgr._client.create_comment.assert_called_once()
+        comment_body = mgr._client.create_comment.call_args.args[1]
+        assert "test failure" in comment_body
+        assert "epic:paused" in comment_body
+        assert "feat-my-feature" in comment_body
+
+    @pytest.mark.asyncio
+    async def test_returns_early_when_no_epic_parent(self):
+        """State with no epic_parent: handle_epic_child_failed is a no-op."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = FeatureState(
+            feature_id="feat-standalone",
+            status=FeatureStatus.failed,
+        )
+
+        mgr = GitHubStateManager.__new__(GitHubStateManager)
+        mgr._client = MagicMock()
+        mgr._client.add_labels = AsyncMock()
+
+        await mgr.handle_epic_child_failed(state)
+
+        mgr._client.add_labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_label_failure_does_not_prevent_comment(self):
+        """If add_labels raises, the method still attempts to post the comment."""
+        from agentharness.github_state import GitHubStateManager
+
+        state = _make_epic_state(
+            status=FeatureStatus.failed,
+            epic_parent=10,
+            state_issue_number=42,
+        )
+
+        mgr = GitHubStateManager.__new__(GitHubStateManager)
+        mgr._client = MagicMock()
+        mgr._client.add_labels = AsyncMock(side_effect=Exception("network error"))
+        mgr._client.create_comment = AsyncMock()
+
+        await mgr.handle_epic_child_failed(state, reason="something bad")
+
+        mgr._client.create_comment.assert_called_once()

--- a/tests/test_epic_dispatch.py
+++ b/tests/test_epic_dispatch.py
@@ -155,7 +155,12 @@ class TestHandleEpicChildDone:
             {"number": 43, "title": "Sub-task 2"},
         ])
         mgr._client.get_default_branch = AsyncMock(return_value="main")
-        mgr._client.create_pull_request = AsyncMock(return_value={"number": 99, "state": "open"})
+        mgr._client.create_pull_request = AsyncMock(return_value={
+            "number": 99,
+            "state": "open",
+            "body": "## Epic\n\nPart of #10\n\n### Tasks\n\n- [ ] #42 Sub-task 1\n- [ ] #43 Sub-task 2",
+        })
+        mgr._client.update_pull_request = AsyncMock(return_value={})
         mgr._client.mark_pr_ready = AsyncMock()
 
         await mgr.handle_epic_child_done(state)
@@ -166,6 +171,11 @@ class TestHandleEpicChildDone:
         body = call_kwargs.kwargs.get("body", "")
         assert "- [ ] #42" in body
         assert "- [ ] #43" in body
+        # First child's checkbox should be ticked via update_pull_request
+        mgr._client.update_pull_request.assert_called_once()
+        updated_body = mgr._client.update_pull_request.call_args.kwargs.get("body", "")
+        assert "- [x] #42" in updated_body
+        assert "- [ ] #43" in updated_body
         # Not last child: should NOT mark ready
         mgr._client.mark_pr_ready.assert_not_called()
 

--- a/tests/test_github_artifacts.py
+++ b/tests/test_github_artifacts.py
@@ -265,6 +265,80 @@ async def test_exists_returns_false_when_git_command_fails() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _checkout_or_create — three-tier fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_checkout_or_create_uses_existing_local_branch() -> None:
+    """First git checkout succeeds — no fallback needed."""
+    store = _make_store()
+    branch = "feat-login-form"
+
+    run_git_calls: list[tuple[str, ...]] = []
+
+    async def fake_run_git(*args: str, cwd: Path | None = None) -> bytes:
+        run_git_calls.append(args)
+        return b""
+
+    with patch("agentharness.github_artifacts._run_git", side_effect=fake_run_git):
+        await store._checkout_or_create(branch)
+
+    # Only one checkout call should have been made
+    assert len(run_git_calls) == 1
+    assert "checkout" in run_git_calls[0]
+    assert branch in run_git_calls[0]
+    # Must NOT include "-b" (not creating a new branch)
+    assert "-b" not in run_git_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_checkout_or_create_falls_back_to_remote_tracking_branch() -> None:
+    """First checkout fails → creates local tracking branch from remote."""
+    store = _make_store()
+    branch = "epic-auth-rewrite"
+
+    call_count = 0
+
+    async def fake_run_git(*args: str, cwd: Path | None = None) -> bytes:
+        nonlocal call_count
+        call_count += 1
+        # First call (plain checkout) fails; subsequent calls succeed
+        if call_count == 1:
+            raise RuntimeError(f"git checkout {branch} failed (exit 1): pathspec not found")
+        return b""
+
+    with patch("agentharness.github_artifacts._run_git", side_effect=fake_run_git):
+        await store._checkout_or_create(branch)
+
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_checkout_or_create_creates_fresh_branch_when_no_remote() -> None:
+    """Both first and second tiers fail → creates a fresh local branch."""
+    store = _make_store()
+    branch = "feat-brand-new"
+
+    call_count = 0
+
+    async def fake_run_git(*args: str, cwd: Path | None = None) -> bytes:
+        nonlocal call_count
+        call_count += 1
+        # First two calls fail; third (fresh branch) succeeds
+        if call_count <= 2:
+            raise RuntimeError(f"git failed (exit 1): not found")
+        return b""
+
+    with patch("agentharness.github_artifacts._run_git", side_effect=fake_run_git):
+        await store._checkout_or_create(branch)
+
+    assert call_count == 3
+    # Third call must use "-b" without a remote ref
+    # (We can't inspect args directly here, but 3 calls means all 3 tiers ran)
+
+
+# ---------------------------------------------------------------------------
 # close
 # ---------------------------------------------------------------------------
 

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -498,3 +498,192 @@ async def test_create_pull_request_reraises_when_label_apply_fails() -> None:
                 title="t", body="b", head="feat", base="main", labels=["agent"]
             )
     await client.close()
+
+
+# ---------------------------------------------------------------------------
+# list_sub_issues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sub_issues_returns_list_of_dicts() -> None:
+    """GET /issues/{n}/sub_issues returns a list of issue dicts."""
+    client = _make_client()
+    sub_issues = [{"number": 2, "title": "child A"}, {"number": 3, "title": "child B"}]
+    with patch.object(
+        client, "_request", new=AsyncMock(return_value=sub_issues)
+    ) as mock_request:
+        result = await client.list_sub_issues(1)
+
+    assert result == sub_issues
+    method, url = mock_request.call_args.args[:2]
+    assert method == "GET"
+    assert url.endswith("/issues/1/sub_issues")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_sub_issues_returns_empty_list_when_none() -> None:
+    """When the API returns an empty array, list_sub_issues returns []."""
+    client = _make_client()
+    with patch.object(client, "_request", new=AsyncMock(return_value=[])):
+        result = await client.list_sub_issues(99)
+
+    assert result == []
+    await client.close()
+
+
+# ---------------------------------------------------------------------------
+# get_parent_issue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_parent_issue_returns_parent_when_field_present() -> None:
+    """When the issue response includes parent_issue, return it."""
+    client = _make_client()
+    parent_data = {"number": 10, "title": "Epic issue"}
+    issue_response = {"number": 42, "title": "child", "parent_issue": parent_data}
+    with patch.object(client, "_request", new=AsyncMock(return_value=issue_response)):
+        result = await client.get_parent_issue(42)
+
+    assert result == parent_data
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_parent_issue_returns_none_when_field_absent() -> None:
+    """When parent_issue is not in the response, return None."""
+    client = _make_client()
+    issue_response = {"number": 5, "title": "standalone issue"}
+    with patch.object(client, "_request", new=AsyncMock(return_value=issue_response)):
+        result = await client.get_parent_issue(5)
+
+    assert result is None
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_parent_issue_returns_none_when_field_is_null() -> None:
+    """When parent_issue is explicitly null/None, return None."""
+    client = _make_client()
+    issue_response = {"number": 7, "title": "no parent", "parent_issue": None}
+    with patch.object(client, "_request", new=AsyncMock(return_value=issue_response)):
+        result = await client.get_parent_issue(7)
+
+    assert result is None
+    await client.close()
+
+
+# ---------------------------------------------------------------------------
+# create_pull_request with draft=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_pull_request_with_draft_true_includes_draft_in_payload() -> None:
+    """draft=True should add 'draft': true to the POST /pulls payload."""
+    client = _make_client()
+    pr_data = {"number": 55, "html_url": "https://github.com/pr/55", "draft": True}
+    with patch.object(
+        client, "_request", new=AsyncMock(return_value=pr_data)
+    ) as mock_request:
+        result = await client.create_pull_request(
+            title="Draft PR", body="WIP", head="feat-x", base="main", draft=True
+        )
+
+    assert result == pr_data
+    payload = mock_request.call_args.kwargs["json"]
+    assert payload["draft"] is True
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_pull_request_default_draft_false_omits_draft_field() -> None:
+    """When draft is not passed (default False), 'draft' should NOT appear in payload."""
+    client = _make_client()
+    pr_data = {"number": 56, "html_url": "https://github.com/pr/56"}
+    with patch.object(
+        client, "_request", new=AsyncMock(return_value=pr_data)
+    ) as mock_request:
+        await client.create_pull_request(
+            title="Normal PR", body="desc", head="feat-y", base="main"
+        )
+
+    payload = mock_request.call_args.kwargs["json"]
+    assert "draft" not in payload
+    await client.close()
+
+
+# ---------------------------------------------------------------------------
+# update_pull_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_pull_request_with_body_and_draft() -> None:
+    """PATCH /pulls/{n} should include only provided fields."""
+    client = _make_client()
+    updated_pr = {"number": 10, "body": "new body", "draft": False}
+    with patch.object(
+        client, "_request", new=AsyncMock(return_value=updated_pr)
+    ) as mock_request:
+        result = await client.update_pull_request(10, body="new body", draft=False)
+
+    assert result == updated_pr
+    method, url = mock_request.call_args.args[:2]
+    assert method == "PATCH"
+    assert url.endswith("/pulls/10")
+    payload = mock_request.call_args.kwargs["json"]
+    assert payload == {"body": "new body", "draft": False}
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_pull_request_with_only_draft() -> None:
+    """When only draft is supplied, payload contains only 'draft'."""
+    client = _make_client()
+    with patch.object(
+        client, "_request", new=AsyncMock(return_value={"number": 11})
+    ) as mock_request:
+        await client.update_pull_request(11, draft=True)
+
+    payload = mock_request.call_args.kwargs["json"]
+    assert payload == {"draft": True}
+    assert "body" not in payload
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_pull_request_with_only_body() -> None:
+    """When only body is supplied, payload contains only 'body'."""
+    client = _make_client()
+    with patch.object(
+        client, "_request", new=AsyncMock(return_value={"number": 12})
+    ) as mock_request:
+        await client.update_pull_request(12, body="updated description")
+
+    payload = mock_request.call_args.kwargs["json"]
+    assert payload == {"body": "updated description"}
+    assert "draft" not in payload
+    await client.close()
+
+
+# ---------------------------------------------------------------------------
+# mark_pr_ready
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_pr_ready_calls_update_pull_request_with_draft_false() -> None:
+    """mark_pr_ready should delegate to update_pull_request(number, draft=False)."""
+    client = _make_client()
+    ready_pr = {"number": 20, "draft": False}
+    with patch.object(
+        client, "update_pull_request", new=AsyncMock(return_value=ready_pr)
+    ) as mock_update:
+        result = await client.mark_pr_ready(20)
+
+    assert result == ready_pr
+    mock_update.assert_awaited_once_with(20, draft=False)
+    await client.close()

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -669,6 +669,15 @@ async def test_update_pull_request_with_only_body() -> None:
     await client.close()
 
 
+@pytest.mark.asyncio
+async def test_update_pull_request_requires_at_least_one_field() -> None:
+    """Calling update_pull_request with no fields should raise ValueError."""
+    client = _make_client()
+    with pytest.raises(ValueError, match="requires at least one field"):
+        await client.update_pull_request(42)
+    await client.close()
+
+
 # ---------------------------------------------------------------------------
 # mark_pr_ready
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds epic support: multiple connected GitHub issues (linked via native sub-issues) can share a single git branch and PR, with each child running the full pipeline sequentially
- Draft PR opened eagerly when the first epic child starts, checkboxes ticked as children complete, marked ready when all are done
- CLI gates `agentharness implement` when a child's parent epic has the `epic:paused` label; pause label + comment are applied automatically on child failure

## What changed

**New API surface (`github_client.py`):** `list_sub_issues`, `get_parent_issue`, `list_pull_requests`, draft-PR support (`create_pull_request(draft=True)`, `update_pull_request`, `mark_pr_ready`).

**State model (`models.py`):** 4 new optional fields on `FeatureState` — `epic_parent`, `epic_position`, `epic_branch`, `epic_total` — fully backward-compatible.

**Branch detection (`brainstorm.py`, `github_artifacts.py`):** `_convert_raw_issue()` detects parent epic, computes `epic_branch = epic-{slug}`, handles position 1 (create branch) vs N>1 (reuse + verify prev sibling done). 3-tier `_checkout_or_create` handles local / remote-only / new branches.

**Dispatcher (`dispatcher.py`, `github_state.py`):** Epic children bypass the regular `_open_feature_pr`; instead `handle_epic_child_done` manages draft PR creation, checkbox ticking, and ready-marking. Non-last epic children on `done` retain their worktree. Failed epic children trigger `handle_epic_child_failed` (EPIC_PAUSED label + retry comment).

**CLI (`cli.py`):** Pre-flight check before `enqueue_planner` refuses to start when parent has `epic:paused` label (GitHub backend only; degrades gracefully on API error).

## Test Plan

- [ ] 578 unit tests pass (`pytest tests/ -q`)
- [ ] Create a parent GitHub issue with 2 sub-issues; run `agentharness implement {child1}` — verify `epic-*` branch created, draft PR opens with checkbox list
- [ ] After child 1 completes, run `agentharness implement {child2}` — verify no new branch created, child 1 checkbox ticked, PR marked ready after child 2 review passes
- [ ] Force child failure (set `max_revisions=0`) — verify `epic:paused` label on parent + comment on failing child
- [ ] Try `agentharness implement {child2}` while parent is paused — verify CLI refuses with clear error
- [ ] Non-epic features: verify no behavior change