### PR TITLE
fix: developer task retry and log file path in state

### DIFF
--- a/agentharness/data/agents/developer.md
+++ b/agentharness/data/agents/developer.md
@@ -11,7 +11,7 @@ allowed_tools:
   - task
 output_format: markdown
 visibility_timeout: 7200
-retry_limit: 1
+retry_limit: 2
 output_parsing: none
 context_files:
   - ~/.claude/plugins/cache/superpowers-marketplace/superpowers/*/skills/subagent-driven-development/SKILL.md

--- a/agentharness/run_task.py
+++ b/agentharness/run_task.py
@@ -87,7 +87,7 @@ async def run_task(queue_name: str, task_json: str, config: Config) -> None:
 
         log.info("[%s] Starting task %s", WORKER_ID, task.task_id)
 
-        started_state = await state_mgr.update(task.feature_id, lambda s: _mark_started(s, task))
+        started_state = await state_mgr.update(task.feature_id, lambda s: _mark_started(s, task, queue_name))
 
         work_dir = store.get_work_dir()
         if work_dir is None and task.work_dir:
@@ -206,13 +206,14 @@ async def _recover_task(
         log.error("[%s] Recovery update failed for %s: %s", WORKER_ID, task.task_id, recovery_exc)
 
 
-def _mark_started(state, task: TaskMessage):
+def _mark_started(state, task: TaskMessage, queue_name: str = ""):
     phase = state.status.value
     pid = os.getpid()
     is_phase_level = not _is_per_task_message(task.task_id, task.feature_id)
+    log_file = str(Path("logs") / queue_name / f"{task.task_id}.log") if queue_name else None
     return (
         state
-        .with_task_update(task.task_id, status=TaskStatus.in_progress, worker_id=WORKER_ID, started_at=datetime.now(UTC), pid=pid)
+        .with_task_update(task.task_id, status=TaskStatus.in_progress, worker_id=WORKER_ID, started_at=datetime.now(UTC), pid=pid, log_file=log_file)
         .with_phase(phase, PhaseInfo(status=PhaseStatus.in_progress, pid=pid if is_phase_level else None))
         .with_event("task_started", phase=phase, task_id=task.task_id, worker_id=WORKER_ID)
     )


### PR DESCRIPTION
Investigated a failed feature in `onpaj/Anela.Heblo` (issue #1399) where a developer agent task failed permanently on its first attempt with no diagnostic trail.

**Root causes found:**
- `retry_limit: 1` in `developer.md` meant zero retries — any single agent failure immediately marked the feature as permanently failed.
- The `log_file` field on `TaskEntry` was never populated, making failed tasks impossible to debug from the GitHub issue state.

**Fixes:**
- Bumped `retry_limit` to `2` so developer tasks get one retry before permanent failure.
- `_mark_started` now records `logs/{queue_name}/{task_id}.log` into the task state, surfacing the observer log path in the issue JSON for post-mortem debugging.