### PR TITLE
Clarify developer agent non-interactive pipeline constraints

### DIFF
--- a/agentharness/data/agents/developer.md
+++ b/agentharness/data/agents/developer.md
@@ -31,7 +31,30 @@ A single task context file containing:
 
 ## Execution
 
-Follow the subagent-driven-development skill exactly: read the task context, then per task dispatch implementer → spec compliance reviewer → code quality reviewer. Do not advance until both reviewers pass.
+You run **non-interactively** inside an automated pipeline. The current working
+directory is already a checkout of the feature branch — every change you make
+must land *there*, on the branch that is already checked out. The pipeline
+commits and pushes that branch and opens the PR for you.
+
+Follow the subagent-driven-development skill for the implement→review loop: read
+the task context, then per task dispatch implementer → spec compliance reviewer →
+code quality reviewer. Do not advance until both reviewers pass.
+
+**Hard constraints — these OVERRIDE anything a skill tells you to do:**
+
+1. **Do NOT create a git worktree, do NOT create a new branch, and do NOT switch
+   branches.** Implement directly in the current working directory on the branch
+   that is already checked out. Creating a worktree or branch puts your code
+   somewhere the pipeline never sees, so it silently vanishes from the PR.
+2. **Commit your work to the current branch.** After each task passes review, run
+   `git add -A && git commit` on the current branch so the code is part of the
+   branch history. Never leave the implementation only on a separate branch.
+3. **Do NOT run the `finishing-a-development-branch` skill and do NOT ask whether
+   to merge, push, or open a PR.** There is no human to answer — the pipeline
+   handles merging and PR creation. Stop as soon as your code is committed on the
+   current branch, then write the output summary below.
+4. **Never wait for interactive input.** If a skill would prompt you with a menu
+   or a question, take the non-interactive path (commit in place) and continue.
 
 ## When you receive review feedback (revision round)
 

--- a/tests/test_github_artifacts.py
+++ b/tests/test_github_artifacts.py
@@ -98,9 +98,10 @@ async def test_upload_runs_git_commands_in_order() -> None:
 
     assert subcommands[0] == "fetch"
     assert subcommands[1] == "checkout"
-    assert subcommands[2] == "add"
-    assert subcommands[3] == "commit"
-    assert subcommands[4] == "push"
+    assert subcommands[2] == "merge"  # ff-only sync with origin before writing
+    assert subcommands[3] == "add"
+    assert subcommands[4] == "commit"
+    assert subcommands[5] == "push"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Updated the developer agent documentation and test expectations to clarify that the agent runs non-interactively within an automated pipeline and must commit code directly to the current branch without creating worktrees or branches.

## Key Changes

- **Developer agent documentation (`developer.md`):**
  - Added explicit section explaining non-interactive pipeline execution model
  - Clarified that the working directory is already a checked-out feature branch
  - Added four hard constraints that override skill instructions:
    1. No git worktrees or branch creation — implement directly in current branch
    2. Commit work to current branch after each task passes review
    3. Do not run `finishing-a-development-branch` skill or ask about merging/pushing
    4. Never wait for interactive input — take non-interactive paths
  - Emphasized that the pipeline handles commits, pushes, and PR creation

- **Test expectations (`test_github_artifacts.py`):**
  - Updated git command sequence assertion to include `merge` (ff-only sync with origin) before writing code
  - Adjusted indices: `add` moved from position 2 to 3, `commit` from 3 to 4, `push` from 4 to 5
  - This reflects the actual pipeline workflow: fetch → checkout → merge → add → commit → push

## Implementation Details

The changes ensure the developer agent understands it operates in a fully automated context where:
- No human interaction is available for prompts or decisions
- Code must be committed to the current branch so the pipeline can push it
- The pipeline itself handles all git operations after the agent completes
- Skills designed for interactive use (like branch creation or PR opening) must be bypassed

This prevents the common failure mode where agent-created worktrees or branches are invisible to the pipeline and code silently vanishes from the PR.

https://claude.ai/code/session_01DrrSkqrm1wHMkK85GLd29f