### PR TITLE
fix: pass --permission-mode bypassPermissions for tool-using agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ implementations/**
 brief.md
 .worktrees/
 .runs-cache/**
+.claude/scheduled_tasks.lock

--- a/agentharness/agent_runner.py
+++ b/agentharness/agent_runner.py
@@ -178,6 +178,11 @@ def _build_command(agent_def: AgentDefinition, prompt: str) -> list[str]:
 
     if agent_def.allowed_tools:
         cmd.extend(["--allowedTools", ",".join(agent_def.allowed_tools)])
+        # Agents that use tools run autonomously in isolated worktrees; without
+        # this, every Edit/Write/Bash file mutation waits forever for an
+        # interactive approval that never arrives, so the agent gives up with
+        # zero output.
+        cmd.extend(["--permission-mode", "bypassPermissions"])
 
     if agent_def.max_turns > 1:
         cmd.extend(["--max-turns", str(agent_def.max_turns)])


### PR DESCRIPTION
## Summary
Claude CLI now requires an explicit `--permission-mode` for non-interactive file writes. Without it, the developer agent's Edit/Write/Bash mutations wait forever for an approval that never arrives, then give up with zero output — leaving plans/specs committed to the feature branch but no actual implementation code. This adds `--permission-mode bypassPermissions` whenever an agent has `allowed_tools` set (safe because those agents run in isolated git worktrees).

## Test plan
- [ ] Re-run a feature stuck at empty `impl/main.r1.md` and confirm code commits appear on the feature branch.