### PR TITLE
feat: limit concurrent workers per queue (default 1)

### DIFF
--- a/agentharness/config.py
+++ b/agentharness/config.py
@@ -97,6 +97,7 @@ class DefaultsConfig(BaseModel):
     max_revisions: int = 3
     poll_interval_seconds: float = 1.0
     github_poll_interval_seconds: float = 60.0
+    max_concurrent_workers: int = 1
 
 
 class Config(BaseModel):

--- a/agentharness/observer.py
+++ b/agentharness/observer.py
@@ -62,6 +62,8 @@ async def observe(config: Config) -> None:
     exe = str(Path(sys.executable).parent / "agentharness")
 
     active_procs: dict[str, asyncio.Process] = {}
+    queue_active: dict[str, int] = {}
+    max_concurrent = config.defaults.max_concurrent_workers
 
     is_github = config.storage_backend == "github"
 
@@ -83,11 +85,11 @@ async def observe(config: Config) -> None:
 
     try:
         if is_github:
-            poll_tasks = [_unified_github_poll(queues, config, exe, active_procs)]
+            poll_tasks = [_unified_github_poll(queues, config, exe, active_procs, queue_active, max_concurrent)]
         else:
             poll_interval = config.defaults.poll_interval_seconds
             poll_tasks = [
-                _poll_queue(q_name, q, config, exe, active_procs, poll_interval)
+                _poll_queue(q_name, q, config, exe, active_procs, queue_active, poll_interval, max_concurrent)
                 for q_name, q in queues.items()
             ]
         poll_tasks.append(_auto_mode_loop(config))
@@ -190,10 +192,15 @@ async def _poll_queue(
     config: Config,
     exe: str,
     active_procs: dict[str, asyncio.Process],
+    queue_active: dict[str, int],
     poll_interval: float,
+    max_concurrent: int,
 ) -> None:
     log.info("Polling %s (interval=%.1fs)", queue_name, poll_interval)
     while True:
+        if queue_active.get(queue_name, 0) >= max_concurrent:
+            await asyncio.sleep(poll_interval)
+            continue
         result = await queue.receive_task(visibility_timeout=_VISIBILITY_TIMEOUT)
         if result is None:
             await asyncio.sleep(poll_interval)
@@ -201,7 +208,7 @@ async def _poll_queue(
         task, raw_msg = result
         log.info("Received task %s from %s", task.task_id, queue_name)
         asyncio.create_task(
-            _run_subprocess(queue_name, task, raw_msg, queue, exe, active_procs),
+            _run_subprocess(queue_name, task, raw_msg, queue, exe, active_procs, queue_active),
             name=f"task-{task.task_id}",
         )
 
@@ -211,6 +218,8 @@ async def _unified_github_poll(
     config: Config,
     exe: str,
     active_procs: dict[str, asyncio.Process],
+    queue_active: dict[str, int],
+    max_concurrent: int,
 ) -> None:
     """Single-search poller for GitHub: one API call per cycle handles polling, sweeping, and state cache."""
     import json
@@ -272,6 +281,8 @@ async def _unified_github_poll(
                 )
                 if not queue_name or queue_name in dispatched or queue_name not in queues:
                     continue
+                if queue_active.get(queue_name, 0) >= max_concurrent:
+                    continue
                 dispatched.add(queue_name)
                 queue = queues[queue_name]
                 if not isinstance(queue, GitHubTaskQueue):
@@ -283,7 +294,7 @@ async def _unified_github_poll(
                     continue
                 log.info("Claimed task %s from %s", task.task_id, queue_name)
                 asyncio.create_task(
-                    _run_subprocess(queue_name, task, raw_msg, queue, exe, active_procs),
+                    _run_subprocess(queue_name, task, raw_msg, queue, exe, active_procs, queue_active),
                     name=f"task-{task.task_id}",
                 )
 
@@ -511,6 +522,7 @@ async def _run_subprocess(
     queue: TaskQueue,
     exe: str,
     active_procs: dict[str, asyncio.Process],
+    queue_active: dict[str, int],
 ) -> None:
     log_dir = Path("logs") / queue_name
     log_dir.mkdir(parents=True, exist_ok=True)
@@ -519,6 +531,7 @@ async def _run_subprocess(
     task_json = task.model_dump_json()
     log.info("Spawning subprocess for %s → %s", task.task_id, log_file)
 
+    queue_active[queue_name] = queue_active.get(queue_name, 0) + 1
     try:
         with open(log_file, "a") as fh:
             from datetime import datetime
@@ -543,6 +556,7 @@ async def _run_subprocess(
         return
     finally:
         active_procs.pop(task.task_id, None)
+        queue_active[queue_name] = max(0, queue_active.get(queue_name, 0) - 1)
 
     if proc.returncode == 0:
         try:

--- a/tests/test_observer_concurrency.py
+++ b/tests/test_observer_concurrency.py
@@ -1,0 +1,158 @@
+"""Tests for per-queue concurrency limiting in the observer."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentharness.models import TaskMessage
+from agentharness.observer import _poll_queue, _run_subprocess
+
+
+def _make_task(task_id: str = "task-1") -> TaskMessage:
+    return TaskMessage(
+        feature_id="feat-test",
+        task_id=task_id,
+        input_artifacts=[],
+        output_artifact="artifacts/feat-test/impl/task-1.r1.md",
+        agent_role="developer",
+    )
+
+
+def _make_raw_msg() -> MagicMock:
+    msg = MagicMock()
+    msg.message_id = "msg-1"
+    return msg
+
+
+def _make_queue() -> MagicMock:
+    q = MagicMock()
+    q.delete_message = AsyncMock()
+    q.extend_visibility = AsyncMock(return_value=_make_raw_msg())
+    q.close = AsyncMock()
+    return q
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_increments_queue_active() -> None:
+    """queue_active[queue_name] is 1 while the subprocess runs."""
+    task = _make_task()
+    queue = _make_queue()
+    active_procs: dict = {}
+    queue_active: dict[str, int] = {}
+    observed_counts: list[int] = []
+
+    async def fake_exec(*args, **kwargs):
+        proc = MagicMock()
+        proc.pid = 1234
+        proc.returncode = 0
+        proc.stdin = MagicMock()
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
+        proc.stdin.close = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        observed_counts.append(queue_active.get("developer-queue", 0))
+        return proc
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("agentharness.observer._wait_with_renewal", new_callable=AsyncMock, return_value=_make_raw_msg()),
+    ):
+        await _run_subprocess("developer-queue", task, _make_raw_msg(), queue, "agentharness", active_procs, queue_active)
+
+    assert observed_counts == [1]
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_decrements_queue_active_on_completion() -> None:
+    """queue_active[queue_name] returns to 0 after subprocess finishes."""
+    task = _make_task()
+    queue = _make_queue()
+    active_procs: dict = {}
+    queue_active: dict[str, int] = {}
+
+    async def fake_exec(*args, **kwargs):
+        proc = MagicMock()
+        proc.pid = 1234
+        proc.returncode = 0
+        proc.stdin = MagicMock()
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
+        proc.stdin.close = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        return proc
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch("agentharness.observer._wait_with_renewal", new_callable=AsyncMock, return_value=_make_raw_msg()),
+    ):
+        await _run_subprocess("developer-queue", task, _make_raw_msg(), queue, "agentharness", active_procs, queue_active)
+
+    assert queue_active.get("developer-queue", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_decrements_queue_active_on_exception() -> None:
+    """queue_active[queue_name] returns to 0 even when subprocess spawning fails."""
+    task = _make_task()
+    queue = _make_queue()
+    active_procs: dict = {}
+    queue_active: dict[str, int] = {}
+
+    with patch("asyncio.create_subprocess_exec", side_effect=OSError("spawn failed")):
+        await _run_subprocess("developer-queue", task, _make_raw_msg(), queue, "agentharness", active_procs, queue_active)
+
+    assert queue_active.get("developer-queue", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_poll_queue_skips_receive_when_at_capacity() -> None:
+    """_poll_queue does not call receive_task when the queue is already at max_concurrent."""
+    from agentharness.config import Config
+
+    config = Config()
+    queue = MagicMock()
+    queue.receive_task = AsyncMock(return_value=None)
+    active_procs: dict = {}
+    queue_active: dict[str, int] = {"developer-queue": 1}  # already at limit
+
+    sleep_calls = 0
+
+    async def mock_sleep(delay: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError
+
+    with patch("asyncio.sleep", side_effect=mock_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            await _poll_queue("developer-queue", queue, config, "agentharness", active_procs, queue_active, 1.0, 1)
+
+    queue.receive_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_queue_receives_when_under_capacity() -> None:
+    """_poll_queue calls receive_task when the queue is below max_concurrent."""
+    from agentharness.config import Config
+
+    config = Config()
+    queue = MagicMock()
+    queue.receive_task = AsyncMock(return_value=None)
+    active_procs: dict = {}
+    queue_active: dict[str, int] = {}  # nothing active
+
+    sleep_calls = 0
+
+    async def mock_sleep(delay: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 1:
+            raise asyncio.CancelledError
+
+    with patch("asyncio.sleep", side_effect=mock_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            await _poll_queue("developer-queue", queue, config, "agentharness", active_procs, queue_active, 1.0, 1)
+
+    queue.receive_task.assert_awaited_once()


### PR DESCRIPTION
Adds a `max_concurrent_workers` config option (default `1`) that limits how many subprocesses the observer will run simultaneously per queue. Previously, the observer could spawn multiple workers for the same queue across poll cycles, allowing e.g. developer tasks from different features to run in parallel.

## Changes

- `agentharness/config.py`: adds `max_concurrent_workers: int = 1` to `DefaultsConfig`
- `agentharness/observer.py`: introduces a `queue_active: dict[str, int]` counter shared across cycles; both the Azure poll loop and the GitHub unified poller skip claiming new tasks when already at capacity; `_run_subprocess` increments on entry and decrements in `finally`
- `tests/test_observer_concurrency.py`: new tests verifying the counter increments/decrements correctly and that polling halts when at capacity

To allow 2 parallel workers per queue, set `"defaults": {"max_concurrent_workers": 2}` in `.pipeline/config.json`.