### PR TITLE
fix: add bypassPermissions for agents with output_file_glob but no tools

### DIFF
--- a/agentharness/agent_runner.py
+++ b/agentharness/agent_runner.py
@@ -176,12 +176,14 @@ def _build_command(agent_def: AgentDefinition, prompt: str) -> list[str]:
         "--output-format", "stream-json",
     ]
 
-    if agent_def.allowed_tools:
-        cmd.extend(["--allowedTools", ",".join(agent_def.allowed_tools)])
-        # Agents that use tools run autonomously in isolated worktrees; without
+    if agent_def.allowed_tools or agent_def.output_file_glob:
+        if agent_def.allowed_tools:
+            cmd.extend(["--allowedTools", ",".join(agent_def.allowed_tools)])
+        # Agents that write files run autonomously in isolated worktrees; without
         # this, every Edit/Write/Bash file mutation waits forever for an
         # interactive approval that never arrives, so the agent gives up with
-        # zero output.
+        # zero output. This applies both to tool-using agents and to tool-less
+        # agents that write output via a skill (output_file_glob set).
         cmd.extend(["--permission-mode", "bypassPermissions"])
 
     if agent_def.max_turns > 1:

--- a/tests/test_agent_runner_build_command.py
+++ b/tests/test_agent_runner_build_command.py
@@ -1,0 +1,51 @@
+"""Tests for _build_command permission-mode and allowed-tools flags."""
+
+from __future__ import annotations
+
+from agentharness.agent_runner import _build_command
+from agentharness.models import AgentDefinition
+
+
+def _make_agent_def(**overrides) -> AgentDefinition:
+    defaults = dict(
+        id="test-agent",
+        model="claude-sonnet-4-6",
+        phase="testing",
+        system_prompt="You are a test agent.",
+        visibility_timeout=600,
+    )
+    return AgentDefinition(**{**defaults, **overrides})
+
+
+def test_allowed_tools_adds_bypass_and_allowed_tools_flag():
+    agent_def = _make_agent_def(allowed_tools=["bash", "read"])
+    cmd = _build_command(agent_def, "do work")
+    assert "--permission-mode" in cmd
+    assert "bypassPermissions" in cmd
+    assert "--allowedTools" in cmd
+    idx = cmd.index("--allowedTools")
+    assert "bash" in cmd[idx + 1]
+
+
+def test_output_file_glob_adds_bypass_without_allowed_tools_flag():
+    """Agents with output_file_glob but no tools must still get bypassPermissions."""
+    agent_def = _make_agent_def(allowed_tools=[], output_file_glob="spec.md")
+    cmd = _build_command(agent_def, "analyse")
+    assert "--permission-mode" in cmd
+    assert "bypassPermissions" in cmd
+    assert "--allowedTools" not in cmd
+
+
+def test_no_tools_no_glob_no_bypass():
+    agent_def = _make_agent_def(allowed_tools=[], output_file_glob=None)
+    cmd = _build_command(agent_def, "review")
+    assert "--permission-mode" not in cmd
+    assert "--allowedTools" not in cmd
+
+
+def test_both_tools_and_glob_adds_both_flags():
+    agent_def = _make_agent_def(allowed_tools=["write"], output_file_glob="design.md")
+    cmd = _build_command(agent_def, "design")
+    assert "--permission-mode" in cmd
+    assert "bypassPermissions" in cmd
+    assert "--allowedTools" in cmd


### PR DESCRIPTION
## Summary

- Agents like `planner`, `analyst`, and `designer` have `output_file_glob` set but `allowed_tools: []` — they write output files via injected skills (e.g. `superpowers:writing-plans`).
- Without `--permission-mode bypassPermissions`, the sandbox blocks those writes, causing _"Sandbox is blocking file writes..."_ in the planning task.
- `_build_command()` in `agent_runner.py` now gates the bypass flag on `allowed_tools OR output_file_glob`, mirroring the identical condition already used in `run_task.py:123`.
- 4 new unit tests cover all combinations of the two flags.

## Test plan

- [x] `pytest tests/test_agent_runner_build_command.py` — 4 new tests, all pass
- [x] Full suite: 733 pass, 2 pre-existing failures unrelated to this change
- [ ] Manually trigger a planning task and confirm plan file is written without sandbox error