### PR TITLE
fix: prevent output-only agents from using Bash and triggering git push on disk-full

### DIFF
--- a/agentharness/agent_runner.py
+++ b/agentharness/agent_runner.py
@@ -179,11 +179,11 @@ def _build_command(agent_def: AgentDefinition, prompt: str) -> list[str]:
     if agent_def.allowed_tools or agent_def.output_file_glob:
         if agent_def.allowed_tools:
             cmd.extend(["--allowedTools", ",".join(agent_def.allowed_tools)])
-        # Agents that write files run autonomously in isolated worktrees; without
-        # this, every Edit/Write/Bash file mutation waits forever for an
-        # interactive approval that never arrives, so the agent gives up with
-        # zero output. This applies both to tool-using agents and to tool-less
-        # agents that write output via a skill (output_file_glob set).
+        elif agent_def.output_file_glob:
+            # Output-only agents (no allowed_tools) need Write/Edit to create their
+            # output file, but nothing else. Restricting here prevents these agents
+            # from running Bash commands (e.g. disk-cleanup) that are out of scope.
+            cmd.extend(["--allowedTools", "write,edit"])
         cmd.extend(["--permission-mode", "bypassPermissions"])
 
     if agent_def.max_turns > 1:

--- a/agentharness/run_task.py
+++ b/agentharness/run_task.py
@@ -89,7 +89,14 @@ async def run_task(queue_name: str, task_json: str, config: Config) -> None:
 
         started_state = await state_mgr.update(task.feature_id, lambda s: _mark_started(s, task, queue_name))
 
-        work_dir = store.get_work_dir()
+        # Developer agents (allowed_tools set) write code to the feature-branch clone.
+        # Output-only agents (output_file_glob, no allowed_tools) just need a scratch
+        # directory for their single output file; using the clone root for them pollutes
+        # the branch with uncommitted debris and triggers unnecessary git pushes.
+        if agent_def.allowed_tools:
+            work_dir = store.get_work_dir()
+        else:
+            work_dir = None
         if work_dir is None and task.work_dir:
             work_dir = Path(task.work_dir)
         if work_dir is None and agent_def.output_file_glob:
@@ -120,7 +127,7 @@ async def run_task(queue_name: str, task_json: str, config: Config) -> None:
         if agent_def.output_file_glob and work_dir:
             result = _resolve_output_file(result, agent_def.output_file_glob, work_dir)
 
-        if agent_def.allowed_tools or agent_def.output_file_glob:
+        if agent_def.allowed_tools:
             committed = await store.commit_workdir_changes(f"agent: {agent_def.id} output {task.task_id}")
             if committed:
                 log.info("[%s] Committed workdir changes for task %s", WORKER_ID, task.task_id)

--- a/tests/test_agent_runner_build_command.py
+++ b/tests/test_agent_runner_build_command.py
@@ -27,13 +27,18 @@ def test_allowed_tools_adds_bypass_and_allowed_tools_flag():
     assert "bash" in cmd[idx + 1]
 
 
-def test_output_file_glob_adds_bypass_without_allowed_tools_flag():
-    """Agents with output_file_glob but no tools must still get bypassPermissions."""
+def test_output_file_glob_adds_bypass_with_restricted_tools():
+    """output_file_glob agents get bypassPermissions + Write/Edit only (no Bash)."""
     agent_def = _make_agent_def(allowed_tools=[], output_file_glob="spec.md")
     cmd = _build_command(agent_def, "analyse")
     assert "--permission-mode" in cmd
     assert "bypassPermissions" in cmd
-    assert "--allowedTools" not in cmd
+    assert "--allowedTools" in cmd
+    idx = cmd.index("--allowedTools")
+    allowed = cmd[idx + 1]
+    assert "write" in allowed
+    assert "edit" in allowed
+    assert "bash" not in allowed
 
 
 def test_no_tools_no_glob_no_bypass():

--- a/tests/test_run_task.py
+++ b/tests/test_run_task.py
@@ -553,29 +553,37 @@ class TestRunTaskGetWorkDir:
 
         mock_store.commit_workdir_changes.assert_awaited_once()
 
-    async def test_output_file_glob_triggers_commit(self, tmp_path: Path):
-        """When output_file_glob is set (no allowed_tools), commit_workdir_changes is still called."""
+    async def test_output_file_glob_skips_commit(self, tmp_path: Path):
+        """output_file_glob agents without allowed_tools must NOT call commit_workdir_changes.
+
+        These agents write a single output file to a temp dir; their content is pushed
+        via store.upload. Committing the clone root for them is unnecessary and risks
+        failing the task on a full disk.
+        """
         task_json, config, mock_store, mock_state_mgr, mock_agent_def, mock_run_result = (
             _make_run_task_fixtures("github")
         )
-        spec_file = tmp_path / "spec.md"
-        spec_file.write_text("# Spec content")
         mock_store.get_work_dir = MagicMock(return_value=tmp_path)
         mock_store.commit_workdir_changes = AsyncMock(return_value=True)
         mock_agent_def.allowed_tools = []
         mock_agent_def.output_file_glob = "spec.md"
+
+        async def run_agent_writes_file(agent_def, prompt, work_dir=None, **kwargs):
+            assert work_dir is not None
+            (work_dir / "spec.md").write_text("# Spec content")
+            return mock_run_result
 
         with (
             patch("agentharness.run_task.create_artifact_store", return_value=mock_store),
             patch("agentharness.run_task.create_state_manager", return_value=mock_state_mgr),
             patch("agentharness.run_task.create_task_queue"),
             patch("agentharness.run_task.load_agent_definition", return_value=mock_agent_def),
-            patch("agentharness.run_task.run_agent", return_value=mock_run_result),
+            patch("agentharness.run_task.run_agent", side_effect=run_agent_writes_file),
             patch("agentharness.run_task.dispatch_after_completion", return_value=None),
         ):
             await run_task("analyst-queue", task_json, config)
 
-        mock_store.commit_workdir_changes.assert_awaited_once()
+        mock_store.commit_workdir_changes.assert_not_awaited()
         content = mock_store.upload.call_args[0][1]
         assert content == "# Spec content"
 
@@ -615,10 +623,10 @@ class TestRunTaskGetWorkDir:
             f"Expected file content to be uploaded, got agent text summary instead: {uploaded_content[:100]!r}"
         )
 
-    async def test_output_file_glob_with_store_work_dir_uses_file_not_text_output(self, tmp_path: Path):
-        """Regression (designer): even when get_work_dir() returns a real path,
-        store.upload must use the file content — not the agent's text summary.
-        Verifies the glob matches the file the agent actually writes (design.md)."""
+    async def test_output_file_glob_uses_temp_dir_not_store_work_dir(self):
+        """Regression (designer): output_file_glob agents without allowed_tools must use a
+        temp dir, not the store's clone root — so store.upload gets the file content, not
+        the agent's text summary, and the clone root is left clean."""
         task_json, config, mock_store, mock_state_mgr, mock_agent_def, mock_run_result = (
             _make_run_task_fixtures("github")
         )
@@ -626,23 +634,30 @@ class TestRunTaskGetWorkDir:
         AGENT_TEXT_SUMMARY = "`design.r1.md` written and committed. Here's what it covers: **UX/UI Design** — ..."
         DESIGN_FILE_CONTENT = "# Design: My Feature\n\n## UX/UI Design\nFull design here."
 
-        (tmp_path / "design.md").write_text(DESIGN_FILE_CONTENT)
-        mock_store.get_work_dir = MagicMock(return_value=tmp_path)
+        store_work_dir = MagicMock()  # pretend clone root — must NOT be used as work_dir
+        mock_store.get_work_dir = MagicMock(return_value=store_work_dir)
         mock_store.commit_workdir_changes = AsyncMock(return_value=True)
         mock_agent_def.allowed_tools = []
         mock_agent_def.output_file_glob = "design.md"
         mock_run_result.output = AGENT_TEXT_SUMMARY
+
+        async def run_agent_writes_file(agent_def, prompt, work_dir=None, **kwargs):
+            assert work_dir is not None, "agent must receive a work_dir"
+            assert work_dir is not store_work_dir, "agent must NOT write directly to clone root"
+            (work_dir / "design.md").write_text(DESIGN_FILE_CONTENT)
+            return mock_run_result
 
         with (
             patch("agentharness.run_task.create_artifact_store", return_value=mock_store),
             patch("agentharness.run_task.create_state_manager", return_value=mock_state_mgr),
             patch("agentharness.run_task.create_task_queue"),
             patch("agentharness.run_task.load_agent_definition", return_value=mock_agent_def),
-            patch("agentharness.run_task.run_agent", return_value=mock_run_result),
+            patch("agentharness.run_task.run_agent", side_effect=run_agent_writes_file),
             patch("agentharness.run_task.dispatch_after_completion", return_value=None),
         ):
             await run_task("designer-queue", task_json, config)
 
+        mock_store.commit_workdir_changes.assert_not_awaited()
         uploaded_content = mock_store.upload.call_args[0][1]
         assert uploaded_content == DESIGN_FILE_CONTENT, (
             f"Expected file content to be uploaded, got agent text summary instead: {uploaded_content[:100]!r}"


### PR DESCRIPTION
## Summary

- Output-only agents (planner, designer — `output_file_glob` set, no `allowed_tools`) were getting `bypassPermissions` with no `--allowedTools` restriction, giving them unrestricted Bash access and causing them to autonomously run disk-cleanup commands when the VM disk was full.
- These agents now receive `--allowedTools write,edit` so they can write their output file but cannot run Bash.
- `commit_workdir_changes` (which does an unguarded `git push`) is now only called for developer agents with `allowed_tools`; output-only agents use a temp dir and upload content via `store.upload` instead of committing to the clone root.

## Test plan

- [ ] All 42 targeted tests in `test_agent_runner_build_command.py` and `test_run_task.py` pass
- [ ] Full suite: 733 passed, 2 pre-existing failures unrelated to these changes
- [ ] Planner/designer agents no longer run disk-cleanup Bash commands
- [ ] Tasks no longer fail with unhandled `git push` errors on a full-disk VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)