### PR TITLE
feat: show GitHub issue ID before feature name in TUI

### DIFF
--- a/agentharness/tui.py
+++ b/agentharness/tui.py
@@ -224,7 +224,8 @@ class FeatureList(ListView):
         short_id = state.feature_id.removeprefix("feat-")
         total = _fmt_tokens(state.total_tokens_used())
         token_part = f"  [dim cyan]{total}[/dim cyan]" if total != "—" else ""
-        return f"[{color}]{icon}[/]  {short_id}  [{color}]{bar}[/]  [dim]{summary}[/dim]{token_part}"
+        issue_prefix = f"[dim]#{state.state_issue_number}[/dim]  " if state.state_issue_number is not None else ""
+        return f"[{color}]{icon}[/]  {issue_prefix}{short_id}  [{color}]{bar}[/]  [dim]{summary}[/dim]{token_part}"
 
     def selected_feature_id(self) -> str | None:
         idx = self.index


### PR DESCRIPTION
Prepends the GitHub issue number (e.g. `#42`) in dimmed style before the feature ID in the TUI feature list. This makes it easy to navigate directly to the corresponding GitHub issue from the monitor view. Falls back gracefully when `state_issue_number` is `None` (e.g. Azure backend).