### PR TITLE
feat: in-pipeline whole-branch code review (replaces @claude action)

### DIFF
--- a/.claude/skills/chopchop/SKILL.md
+++ b/.claude/skills/chopchop/SKILL.md
@@ -39,8 +39,8 @@ gh pr list --state all --json number,headRefName \
 
 4. **Run oneshot on it.** Invoke the `oneshot` skill on the selected issue
    number — this drives the full pipeline (worktree on `feature/{N}-{slug}`,
-   label lifecycle `agent` → `agent-wip` → `agent-completed`, tests, `@claude`
-   commit, push, and the `agent`-labelled PR):
+   label lifecycle `agent` → `agent-wip` → `agent-completed`, tests, in-pipeline
+   code review, push, and the `agent`-labelled PR):
 ```
 /oneshot {N}
 ```

--- a/.claude/skills/oneshot/SKILL.md
+++ b/.claude/skills/oneshot/SKILL.md
@@ -115,13 +115,12 @@ artifacts/feat-{issue_id}/state.json          # checkpoint state
 ```bash
 git add -A artifacts/feat-{issue_id}    # ensure all generated .md artifacts are staged
 git add -A                              # stage code + everything else
-git commit --allow-empty -m "implement feat-{issue_id} @claude"
+git commit --allow-empty -m "implement feat-{issue_id}"
 ```
-   The commit message **must end with** `@claude` (the trigger phrase goes at the
-   very end of the message, not the start). Use `--allow-empty` so this marker
-   commit always becomes `HEAD` — even when the orchestrator already committed
-   every artifact — otherwise the `@claude` trigger never reaches the tip of the
-   branch and the GitHub Claude review is not invoked.
+   Use `--allow-empty` so this commit always becomes `HEAD`, capturing any
+   remaining artifacts. The whole-branch code review already ran inside the
+   pipeline (see the orchestrator's Code Review phase), so no external review
+   trigger is needed.
 
 3. **Push** the branch:
 ```bash
@@ -143,14 +142,25 @@ git push -u origin "$BRANCH"
    Open the PR (base = the repository default branch, head = `$BRANCH`). Capture
    the PR URL and attach the `agent` label in a **separate, explicit step** — do
    not rely on `--label` on `gh pr create` alone, as it is sometimes silently
-   dropped. The `gh pr edit --add-label` call is the guarantee:
+   dropped. The `gh pr edit --add-label` call is the guarantee.
+
+   First capture the pipeline's final code review so it can be surfaced on the PR.
+   The `## Code review` section carries the whole-branch review run inside the
+   pipeline — advisory cleanups and any unresolved correctness findings:
 ```bash
+# Most recent code-review artifact (highest revision), if any.
+REVIEW_FILE=$(ls -1 artifacts/feat-{issue_id}/code-review.r*.md 2>/dev/null | sort -V | tail -n1)
+REVIEW_SECTION=""
+if [ -n "$REVIEW_FILE" ]; then
+  REVIEW_SECTION=$(printf '\n## Code review\n\n%s\n' "$(cat "$REVIEW_FILE")")
+fi
+
 PR_URL=$(gh pr create \
   --base master \
   --head "$BRANCH" \
   --label agent \
   --title "#{issue_id}: implementation" \
-  --body "$(cat <<'EOF'
+  --body "$(cat <<EOF
 Closes #{issue_id}
 
 ## What the issue was
@@ -161,6 +171,7 @@ Closes #{issue_id}
 
 ## Artifacts
 - Brief, spec, design, task plan, impl, and review markdown are committed in this branch.
+${REVIEW_SECTION}
 EOF
 )")
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ A distributed, event-driven pipeline that autonomously processes development tas
   designer.md       Design document generator
   planner.md        Task planning from spec (fan-out)
   developer.md      Code implementation (serial, per-task review)
-  reviewer.md       Per-task review with PASS/REVISION_NEEDED
+  reviewer.md       Per-task review of the developer's summary (PASS/REVISION_NEEDED)
+  code-reviewer.md  Final whole-branch diff review (allowed_tools: bash,read,grep,glob)
   brainstorm.md     Interactive brief discovery (CLI skill)
 .claude/agents/     Claude Code skills (brainstorm, implement, azure-storage)
 .pipeline/          Runtime config (queue → agent mapping, timeouts)
@@ -93,7 +94,7 @@ agentharness _run_task                          # single-task runner (reads JSON
 ## State machine
 
 ```
-brainstorming → analyzing → architecting → designing → planning → developing → reviewing → done
+brainstorming → analyzing → architecting → designing → planning → developing → reviewing → code-review → done
                                                                        ↑              |
                                                                   dev_revision ←------+
                                                                        |
@@ -101,6 +102,13 @@ brainstorming → analyzing → architecting → designing → planning → deve
 ```
 
 `failed` is reachable from any state after `dead_letter_threshold` retries or `max_revisions` revision rounds.
+
+After all developer tasks pass per-task review (`reviewing`), the orchestrator runs a
+final **`code-review`** phase: it diffs the whole feature branch against its merge-base
+with `master` and hands the diff to the `code-reviewer` agent. Correctness findings
+trigger a developer fix round (bounded by `max_revisions`); reuse/simplification/
+efficiency cleanups are advisory. The final review is attached to the PR body. This
+replaces the previous external `@claude` GitHub Action review.
 
 ### Task status values (`TaskStatus`)
 
@@ -198,6 +206,7 @@ artifacts/{feature_id}/design.r1.md            # designer output
 artifacts/{feature_id}/task-plan.r1.md         # planner output
 artifacts/{feature_id}/impl/{task}.r1.md       # r{N} = revision number
 artifacts/{feature_id}/review/{task}.r1.md
+artifacts/{feature_id}/code-review.r1.md       # final whole-branch review per round
 artifacts/{feature_id}/state.json
 ```
 

--- a/agentharness/data/agents/code-reviewer.md
+++ b/agentharness/data/agents/code-reviewer.md
@@ -1,0 +1,62 @@
+---
+id: code-reviewer
+display_name: "Code Reviewer Agent"
+model: claude-sonnet-4-6
+phase: code-review
+max_turns: 30
+allowed_tools: [bash, read, grep, glob]
+output_format: markdown
+visibility_timeout: 1800
+retry_limit: 2
+output_parsing: none
+---
+
+You are a senior code reviewer performing a final review of an entire feature
+branch before its pull request is opened. You review the **real code diff**, not a
+summary. The pipeline parses your output programmatically — follow the output
+format exactly.
+
+## Your inputs
+
+- The unified diff of the whole feature branch versus its merge-base with the base
+  branch (provided in the prompt).
+- `spec.r1.md` — the feature specification, for understanding intent.
+- You may use `read`, `grep`, and `glob` to inspect any file in the working tree for
+  context (surrounding code, callers, existing helpers).
+
+## Review philosophy
+
+Mirror a focused, high-signal diff review. Report only findings you are
+**high-confidence** about. When unsure, stay silent — a noisy review is worse than a
+short one. Do not report style or formatting nits.
+
+Look for exactly two kinds of findings:
+
+1. **Correctness bugs** — logic errors, wrong conditions, missing error handling,
+   broken edge cases, security issues, data loss, race conditions, contract
+   violations against the spec. These are the only findings that block.
+2. **Cleanups** — reuse (duplicated logic that should call an existing helper),
+   simplification (needless complexity, dead code, over-engineering), and efficiency
+   (obvious avoidable work). These never block; they are advisory.
+
+## Decision rule
+
+- If there is **at least one correctness bug**, the result is `CHANGES_REQUESTED`.
+- Otherwise the result is `CLEAN` (even if you listed advisory cleanups).
+
+## CRITICAL: Output format
+
+Output only the review markdown — no preamble. Use this exact structure:
+
+## Review Result: CLEAN | CHANGES_REQUESTED
+
+### Blocking (correctness)
+- `path/to/file.py:42` — <the bug, why it is wrong, and what to change>
+
+### Advisory (cleanup)
+- `path/to/file.py:88` — <reuse / simplification / efficiency suggestion>
+
+Rules:
+- Put the literal word `CLEAN` or `CHANGES_REQUESTED` after `## Review Result:`.
+- If a section has no findings, write `- None` under it (keep the header).
+- Every finding starts with a `` `path:line` `` reference so fixes are actionable.

--- a/agentharness/data/claude-agents/orchestrator.md
+++ b/agentharness/data/claude-agents/orchestrator.md
@@ -69,10 +69,8 @@ For each phase:
 5. After Task completes, verify the output artifact file exists
 6. Run `agentharness checkpoint phase feat-{issue_number} {phase} completed`
 7. **Commit the artifact to the feature branch** so it lands in the PR, then
-   hard-verify it is tracked (see **Artifact persistence**). Use a plain
-   (non-`@claude`) message — these commits happen before the developer phase, so
-   they never interfere with the skip-review check. `{output_artifact}` is this
-   phase's output file from the mapping below (e.g. `spec.r1.md`):
+   hard-verify it is tracked (see **Artifact persistence**). `{output_artifact}` is
+   this phase's output file from the mapping below (e.g. `spec.r1.md`):
 ```bash
 git add -A artifacts/feat-{issue_number}
 git commit -m "chore(feat-{issue_number}): {phase} artifact" || true   # no-op if nothing changed
@@ -121,36 +119,9 @@ Process tasks serially in the order from the checkpoint. Check `agentharness che
    - Content of `artifacts/feat-{issue_number}/task-context/{task_name}.md`
    - If revision > 1: content of `artifacts/feat-{issue_number}/review/{task_name}.r{N-1}.md` as review feedback
    - Instruction: "Write your implementation output summary to `artifacts/feat-{issue_number}/impl/{task_name}.r{N}.md`"
-6. After Task completes, verify `impl/{task_name}.r{N}.md` exists. **Do not commit
-   the impl artifact yet** — the Skip-Review Check below reads `git log -1`, so
-   the developer's own commit must stay the latest commit until that check runs.
-
-### Skip-Review Check
-
-Before spawning the reviewer, inspect the latest commit the developer made on the
-current branch:
-
-```bash
-git log -1 --format=%B
-```
-
-If the commit message contains `@claude`, **skip the Reviewer Task entirely** and
-treat the task as if review returned `PASS`:
-
-1. Run `agentharness checkpoint task feat-{issue_number} {task_name} completed`
-2. **Now commit the impl artifact** (the skip-review log check has already run, so
-   this commit no longer affects it), then hard-verify it is tracked (see
-   **Artifact persistence**):
-```bash
-git add -A artifacts/feat-{issue_number}
-git commit -m "chore(feat-{issue_number}): impl artifact for {task_name} r{N}" || true
-git ls-files --error-unmatch artifacts/feat-{issue_number}/impl/{task_name}.r{N}.md   # STRICT
-```
-3. Note in your progress output that review was skipped because the commit was
-   marked `@claude`.
-4. Move to the next task via `agentharness checkpoint status feat-{issue_number}`.
-
-Otherwise (no `@claude` in the commit message), run the Reviewer Task below.
+6. After Task completes, verify `impl/{task_name}.r{N}.md` exists. Proceed
+   directly to the Reviewer Task below; the impl artifact is committed together
+   with the review artifact in **Handling Review Result**.
 
 ### Reviewer Task
 
@@ -199,7 +170,73 @@ git ls-files --error-unmatch artifacts/feat-{issue_number}/state.json   # STRICT
 UNTRACKED=$(git ls-files --others --exclude-standard artifacts/feat-{issue_number})
 if [ -n "$UNTRACKED" ]; then echo "ERROR: untracked artifacts remain:"; echo "$UNTRACKED"; exit 1; fi
 ```
-3. Print: `Pipeline complete for feat-{issue_number}. All tasks passed review.`
+3. Run the **Code Review phase** below.
+
+## Code Review phase
+
+After `developing` is `completed` and all developer artifacts are committed, run a
+final whole-branch code review before the pipeline reports complete. The review round
+number `N` is `1 + (count of existing artifacts/feat-{issue_number}/code-review.r*.md
+files)`. The loop is bounded by `max_revisions` from the checkpoint JSON (default 3).
+
+Repeat the following until the review is `CLEAN`, only advisory findings remain, or
+`N > max_revisions`:
+
+1. Run `agentharness checkpoint phase feat-{issue_number} code-review in_progress`.
+2. Build the feature diff against the merge-base with the base branch:
+```bash
+BASE=$(git merge-base master HEAD) || BASE=master
+git diff "$BASE"...HEAD > /tmp/feat-{issue_number}-review.diff
+```
+   If the diff is empty (no code changed), skip straight to step 7 with result
+   `CLEAN`.
+3. Read the `.agents/code-reviewer.md` system prompt (strip frontmatter).
+4. Spawn a Task with:
+   - System prompt from `code-reviewer.md`
+   - The contents of `/tmp/feat-{issue_number}-review.diff` (the full diff)
+   - The contents of `artifacts/feat-{issue_number}/spec.r1.md` (intent)
+   - Instruction: "Write your review to
+     `artifacts/feat-{issue_number}/code-review.r{N}.md` using the required output
+     format. The first line of the result section must be exactly
+     `## Review Result: CLEAN` or `## Review Result: CHANGES_REQUESTED`."
+5. Commit the review artifact and hard-verify it is tracked (see **Artifact
+   persistence**):
+```bash
+git add -A artifacts/feat-{issue_number}
+git commit -m "chore(feat-{issue_number}): code review r{N}" || true
+git ls-files --error-unmatch artifacts/feat-{issue_number}/code-review.r{N}.md
+```
+6. Read `artifacts/feat-{issue_number}/code-review.r{N}.md` and parse the
+   `## Review Result:` line. If the line is missing or unparseable, retry the Task
+   once; if it still fails, treat the result as `CLEAN` and append a
+   `> reviewer-output-unparseable` note to the artifact (never hard-block the feature
+   on a flaky reviewer).
+7. Act on the result:
+   - **CLEAN** (or `CHANGES_REQUESTED` with `- None` under Blocking): run
+     `agentharness checkpoint phase feat-{issue_number} code-review completed` and
+     leave the code-review loop.
+   - **CHANGES_REQUESTED** with Blocking findings and `N < max_revisions`: dispatch a
+     developer revision round to fix them, then loop back to step 1 with `N+1`:
+     1. Write the Blocking findings into a synthetic task-context file
+        `artifacts/feat-{issue_number}/task-context/code-review-fixes.md` containing a
+        `## Goal` of "Fix the code review findings below" and the verbatim Blocking
+        list from `code-review.r{N}.md`.
+     2. Read `.agents/developer.md` (strip frontmatter; include its `context_files`).
+     3. Spawn a developer Task with that task-context as the input and the instruction
+        to fix every Blocking finding in place on the current branch and commit, then
+        write a short summary to
+        `artifacts/feat-{issue_number}/impl/code-review-fixes.r{N}.md`.
+     4. Commit + hard-verify both the task-context and the impl summary artifacts.
+   - **CHANGES_REQUESTED** with Blocking findings and `N >= max_revisions`: run
+     `agentharness checkpoint phase feat-{issue_number} code-review completed` (do NOT
+     fail the whole feature). The unresolved Blocking findings stay in
+     `code-review.r{N}.md` and are surfaced on the PR by the oneshot skill.
+
+After the loop, the latest `artifacts/feat-{issue_number}/code-review.r{N}.md` is the
+final review. Its **Advisory** list, and any unresolved **Blocking** list, are what the
+oneshot skill appends to the PR body.
+
+Then print: `Pipeline complete for feat-{issue_number}. All tasks passed review.`
 
 ## Resume
 

--- a/docs/superpowers/plans/2026-06-22-in-pipeline-code-review.md
+++ b/docs/superpowers/plans/2026-06-22-in-pipeline-code-review.md
@@ -1,0 +1,512 @@
+# In-Pipeline Whole-Branch Code Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a final whole-branch code-review stage to the AgentHarness pipeline that reviews the real feature diff before the PR is opened, drives a bounded auto-fix loop, and replaces the external `@claude` GitHub Action review.
+
+**Architecture:** A new orchestrator-driven phase (`code-review`) runs after all developer tasks complete. It diffs the feature branch against its merge-base with `master`, hands the diff to a new `code-reviewer` agent (which reads real code), and parses the result. Correctness findings block and trigger a developer revision round (reusing existing machinery, bounded by `max_revisions`); cleanup findings are advisory and attached to the PR. The `@claude` marker commit and the orchestrator's Skip-Review Check are removed.
+
+**Tech Stack:** Python 3.11+, Pydantic, Click, pytest. Agent definitions are Markdown-with-YAML-frontmatter under `agentharness/data/agents/`. The orchestrator and skills are Markdown prompt files.
+
+## Global Constraints
+
+- Agent definition files live in `agentharness/data/agents/` and are parsed by `agentharness/prompt_builder.py:load_agent_definition` into `agentharness.models.AgentDefinition`. Required frontmatter fields: `id`, `model`, `phase`, `system_prompt` (body).
+- `agentharness init` copies the entire `data/agents/` dir → target `.agents/` and `data/claude-agents/` → target `.claude/agents/`. No manifest/allowlist to update — new files in those dirs ship automatically.
+- The orchestrator (`agentharness/data/claude-agents/orchestrator.md`) references agents by their installed path `.agents/{name}.md`.
+- Round count for the review loop is derived from existing `code-review.r{N}.md` artifacts — do NOT add a checkpoint field. Bounded by the checkpoint's existing `max_revisions` (default 3).
+- `agentharness checkpoint phase <feature_id> <phase> <status>` already accepts an arbitrary phase string (`checkpoint.update_phase` stores it verbatim) — `code-review` needs no Python/model change.
+- Run tests with the project venv: `.venv/bin/pytest tests/ -v`. Keep existing tests green.
+- Conventional-commit messages. Do not commit unless a step says to.
+
+## File Structure
+
+- `agentharness/data/agents/code-reviewer.md` — **new** agent definition (the whole-branch reviewer). One responsibility: review a diff, emit a parseable PASS/CHANGES result split into Blocking/Advisory.
+- `agentharness/data/claude-agents/orchestrator.md` — **modify**: remove Skip-Review Check; add the Code Review phase in Completion.
+- `.claude/skills/oneshot/SKILL.md` — **modify**: drop the `@claude` marker commit; append the code-review summary to the PR body.
+- `tests/test_code_reviewer_agent.py` — **new**: asserts the new agent definition parses with the required runtime fields.
+- `tests/test_pipeline_review_wiring.py` — **new**: regression guard that the `@claude` trigger is gone and the orchestrator wires the `code-review` phase.
+- `docs/superpowers/specs/2026-06-22-in-pipeline-code-review-design.md` — the approved design (already written).
+
+---
+
+### Task 1: New `code-reviewer` agent definition
+
+Creates the agent that performs the whole-branch review. TDD anchor: a unit test that loads the definition via the real parser and asserts the runtime-critical fields (it must have code-reading tools and the `code-review` phase).
+
+**Files:**
+- Create: `agentharness/data/agents/code-reviewer.md`
+- Test: `tests/test_code_reviewer_agent.py`
+
+**Interfaces:**
+- Consumes: `agentharness.prompt_builder.load_agent_definition(path: Path) -> AgentDefinition`; `AgentDefinition` fields `id, model, phase, max_turns, allowed_tools, output_parsing, system_prompt`.
+- Produces: an installed `.agents/code-reviewer.md` the orchestrator (Task 2) reads. The agent's contract for the orchestrator: its output contains a line `## Review Result: CLEAN` or `## Review Result: CHANGES_REQUESTED`, plus `### Blocking (correctness)` and `### Advisory (cleanup)` sections.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_code_reviewer_agent.py`:
+
+```python
+from pathlib import Path
+
+from agentharness.prompt_builder import load_agent_definition
+
+AGENT_PATH = Path("agentharness/data/agents/code-reviewer.md")
+
+
+def test_code_reviewer_agent_parses_with_runtime_fields():
+    agent = load_agent_definition(AGENT_PATH)
+
+    assert agent.id == "code-reviewer"
+    assert agent.phase == "code-review"
+    # Must be able to read real code, not just a text summary.
+    assert agent.allowed_tools is not None
+    assert "read" in agent.allowed_tools
+    assert "bash" in agent.allowed_tools
+    # Orchestrator parses the result itself; no built-in parser.
+    assert agent.output_parsing == "none"
+    assert agent.system_prompt.strip() != ""
+
+
+def test_code_reviewer_prompt_defines_parseable_result_contract():
+    body = AGENT_PATH.read_text(encoding="utf-8")
+
+    # The exact tokens the orchestrator greps for must be present.
+    assert "## Review Result: CLEAN | CHANGES_REQUESTED" in body
+    assert "### Blocking (correctness)" in body
+    assert "### Advisory (cleanup)" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_code_reviewer_agent.py -v`
+Expected: FAIL — `code-reviewer.md` does not exist (`load_agent_definition` raises `FileNotFoundError` / read error).
+
+- [ ] **Step 3: Create the agent definition**
+
+Create `agentharness/data/agents/code-reviewer.md`:
+
+```markdown
+---
+id: code-reviewer
+display_name: "Code Reviewer Agent"
+model: claude-sonnet-4-6
+phase: code-review
+max_turns: 30
+allowed_tools: [bash, read, grep, glob]
+output_format: markdown
+visibility_timeout: 1800
+retry_limit: 2
+output_parsing: none
+---
+
+You are a senior code reviewer performing a final review of an entire feature
+branch before its pull request is opened. You review the **real code diff**, not a
+summary. The pipeline parses your output programmatically — follow the output
+format exactly.
+
+## Your inputs
+
+- The unified diff of the whole feature branch versus its merge-base with the base
+  branch (provided in the prompt).
+- `spec.r1.md` — the feature specification, for understanding intent.
+- You may use `read`, `grep`, and `glob` to inspect any file in the working tree for
+  context (surrounding code, callers, existing helpers).
+
+## Review philosophy
+
+Mirror a focused, high-signal diff review. Report only findings you are
+**high-confidence** about. When unsure, stay silent — a noisy review is worse than a
+short one. Do not report style or formatting nits.
+
+Look for exactly two kinds of findings:
+
+1. **Correctness bugs** — logic errors, wrong conditions, missing error handling,
+   broken edge cases, security issues, data loss, race conditions, contract
+   violations against the spec. These are the only findings that block.
+2. **Cleanups** — reuse (duplicated logic that should call an existing helper),
+   simplification (needless complexity, dead code, over-engineering), and efficiency
+   (obvious avoidable work). These never block; they are advisory.
+
+## Decision rule
+
+- If there is **at least one correctness bug**, the result is `CHANGES_REQUESTED`.
+- Otherwise the result is `CLEAN` (even if you listed advisory cleanups).
+
+## CRITICAL: Output format
+
+Output only the review markdown — no preamble. Use this exact structure:
+
+## Review Result: CLEAN | CHANGES_REQUESTED
+
+### Blocking (correctness)
+- `path/to/file.py:42` — <the bug, why it is wrong, and what to change>
+
+### Advisory (cleanup)
+- `path/to/file.py:88` — <reuse / simplification / efficiency suggestion>
+
+Rules:
+- Put the literal word `CLEAN` or `CHANGES_REQUESTED` after `## Review Result:`.
+- If a section has no findings, write `- None` under it (keep the header).
+- Every finding starts with a `` `path:line` `` reference so fixes are actionable.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_code_reviewer_agent.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agentharness/data/agents/code-reviewer.md tests/test_code_reviewer_agent.py
+git commit -m "feat: add code-reviewer agent for whole-branch diff review"
+```
+
+---
+
+### Task 2: Orchestrator — add Code Review phase, remove Skip-Review Check
+
+Wires the new agent into the pipeline: a `code-review` phase after `developing` completes, with the bounded auto-fix loop; and removes the `@claude`-based Skip-Review Check so the per-task reviewer always runs as designed.
+
+**Files:**
+- Modify: `agentharness/data/claude-agents/orchestrator.md`
+- Test: `tests/test_pipeline_review_wiring.py` (created here, extended in Task 3)
+
+**Interfaces:**
+- Consumes: the `code-reviewer` agent contract from Task 1 (`## Review Result:` + Blocking/Advisory sections); existing `agentharness checkpoint phase` CLI; the developer agent (`.agents/developer.md`) for revision rounds.
+- Produces: `artifacts/feat-{id}/code-review.r{N}.md` artifacts and the in-prompt variables the oneshot skill (Task 3) reads to build the PR body.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Create `tests/test_pipeline_review_wiring.py`:
+
+```python
+from pathlib import Path
+
+ORCHESTRATOR = Path("agentharness/data/claude-agents/orchestrator.md")
+
+
+def test_orchestrator_defines_code_review_phase():
+    body = ORCHESTRATOR.read_text(encoding="utf-8")
+    assert "## Code Review phase" in body
+    assert "code-review.r{N}.md" in body
+    assert "merge-base master HEAD" in body
+    # Reads the new agent.
+    assert ".agents/code-reviewer.md" in body
+
+
+def test_orchestrator_no_longer_skips_review_on_at_claude():
+    body = ORCHESTRATOR.read_text(encoding="utf-8")
+    # The Skip-Review Check and its @claude trigger must be gone.
+    assert "Skip-Review Check" not in body
+    assert "@claude" not in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_pipeline_review_wiring.py -v`
+Expected: FAIL — orchestrator still contains `Skip-Review Check` / `@claude` and has no Code Review phase.
+
+- [ ] **Step 3: Remove the Skip-Review Check from the orchestrator**
+
+In `agentharness/data/claude-agents/orchestrator.md`:
+
+1. Delete the entire **`### Skip-Review Check`** section (the block that runs `git log -1 --format=%B`, checks for `@claude`, and conditionally skips the Reviewer Task — currently lines ~129–153, ending at the sentence "Otherwise (no `@claude` in the commit message), run the Reviewer Task below.").
+2. In the **`### Developer Task`** section, step 6 currently says *"Do not commit the impl artifact yet — the Skip-Review Check below reads `git log -1` …"*. Replace that justification so it no longer references the skip check:
+
+   Replace:
+   ```
+   6. After Task completes, verify `impl/{task_name}.r{N}.md` exists. **Do not commit
+      the impl artifact yet** — the Skip-Review Check below reads `git log -1`, so
+      the developer's own commit must stay the latest commit until that check runs.
+   ```
+   With:
+   ```
+   6. After Task completes, verify `impl/{task_name}.r{N}.md` exists. Proceed
+      directly to the Reviewer Task below; the impl artifact is committed together
+      with the review artifact in **Handling Review Result**.
+   ```
+3. The **`### Reviewer Task`** section now always runs (no skip). Leave it unchanged.
+
+- [ ] **Step 4: Add the Code Review phase to the orchestrator Completion section**
+
+In `agentharness/data/claude-agents/orchestrator.md`, replace the **`## Completion`** section so the code-review loop runs after `developing completed` and before the pipeline reports complete. Insert this block immediately after the existing step that runs `agentharness checkpoint phase feat-{issue_number} developing completed` and the final artifact safety-net commit, and **before** the final `Print: Pipeline complete` line:
+
+````markdown
+## Code Review phase
+
+After `developing` is `completed` and all developer artifacts are committed, run a
+final whole-branch code review before the pipeline reports complete. The review round
+number `N` is `1 + (count of existing artifacts/feat-{issue_number}/code-review.r*.md
+files)`. The loop is bounded by `max_revisions` from the checkpoint JSON (default 3).
+
+Repeat the following until the review is `CLEAN`, only advisory findings remain, or
+`N > max_revisions`:
+
+1. Run `agentharness checkpoint phase feat-{issue_number} code-review in_progress`.
+2. Build the feature diff against the merge-base with the base branch:
+```bash
+BASE=$(git merge-base master HEAD) || BASE=master
+git diff "$BASE"...HEAD > /tmp/feat-{issue_number}-review.diff
+```
+   If the diff is empty (no code changed), skip straight to step 7 with result
+   `CLEAN`.
+3. Read the `.agents/code-reviewer.md` system prompt (strip frontmatter).
+4. Spawn a Task with:
+   - System prompt from `code-reviewer.md`
+   - The contents of `/tmp/feat-{issue_number}-review.diff` (the full diff)
+   - The contents of `artifacts/feat-{issue_number}/spec.r1.md` (intent)
+   - Instruction: "Write your review to
+     `artifacts/feat-{issue_number}/code-review.r{N}.md` using the required output
+     format. The first line of the result section must be exactly
+     `## Review Result: CLEAN` or `## Review Result: CHANGES_REQUESTED`."
+5. Commit the review artifact and hard-verify it is tracked (see **Artifact
+   persistence**):
+```bash
+git add -A artifacts/feat-{issue_number}
+git commit -m "chore(feat-{issue_number}): code review r{N}" || true
+git ls-files --error-unmatch artifacts/feat-{issue_number}/code-review.r{N}.md
+```
+6. Read `artifacts/feat-{issue_number}/code-review.r{N}.md` and parse the
+   `## Review Result:` line. If the line is missing or unparseable, retry the Task
+   once; if it still fails, treat the result as `CLEAN` and append a
+   `> reviewer-output-unparseable` note to the artifact (never hard-block the feature
+   on a flaky reviewer).
+7. Act on the result:
+   - **CLEAN** (or `CHANGES_REQUESTED` with `- None` under Blocking): run
+     `agentharness checkpoint phase feat-{issue_number} code-review completed` and
+     leave the code-review loop.
+   - **CHANGES_REQUESTED** with Blocking findings and `N < max_revisions`: dispatch a
+     developer revision round to fix them, then loop back to step 1 with `N+1`:
+     1. Write the Blocking findings into a synthetic task-context file
+        `artifacts/feat-{issue_number}/task-context/code-review-fixes.md` containing a
+        `## Goal` of "Fix the code review findings below" and the verbatim Blocking
+        list from `code-review.r{N}.md`.
+     2. Read `.agents/developer.md` (strip frontmatter; include its `context_files`).
+     3. Spawn a developer Task with that task-context as the input and the instruction
+        to fix every Blocking finding in place on the current branch and commit, then
+        write a short summary to
+        `artifacts/feat-{issue_number}/impl/code-review-fixes.r{N}.md`.
+     4. Commit + hard-verify both the task-context and the impl summary artifacts.
+   - **CHANGES_REQUESTED** with Blocking findings and `N >= max_revisions`: run
+     `agentharness checkpoint phase feat-{issue_number} code-review completed` (do NOT
+     fail the whole feature). The unresolved Blocking findings stay in
+     `code-review.r{N}.md` and are surfaced on the PR by the oneshot skill.
+
+After the loop, the latest `artifacts/feat-{issue_number}/code-review.r{N}.md` is the
+final review. Its **Advisory** list, and any unresolved **Blocking** list, are what the
+oneshot skill appends to the PR body.
+````
+
+Then leave the existing final `Print: Pipeline complete for feat-{issue_number}.` line as the last step.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_pipeline_review_wiring.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite to confirm no regressions**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: PASS (all existing tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agentharness/data/claude-agents/orchestrator.md tests/test_pipeline_review_wiring.py
+git commit -m "feat: add code-review phase to orchestrator, drop @claude skip-review"
+```
+
+---
+
+### Task 3: oneshot skill — drop `@claude` trigger, attach review summary to PR body
+
+Removes the external Claude Code Action trigger and instead surfaces the in-pipeline review on the PR.
+
+**Files:**
+- Modify: `.claude/skills/oneshot/SKILL.md`
+- Test: `tests/test_pipeline_review_wiring.py` (extend with oneshot assertions)
+
+**Interfaces:**
+- Consumes: the final `artifacts/feat-{id}/code-review.r{N}.md` produced by Task 2.
+- Produces: a PR whose body includes the review summary and no longer relies on `@claude`.
+
+- [ ] **Step 1: Extend the regression test (write failing assertions)**
+
+Append to `tests/test_pipeline_review_wiring.py`:
+
+```python
+ONESHOT = Path(".claude/skills/oneshot/SKILL.md")
+
+
+def test_oneshot_skill_drops_at_claude_trigger():
+    body = ONESHOT.read_text(encoding="utf-8")
+    assert "@claude" not in body
+
+
+def test_oneshot_skill_attaches_code_review_to_pr_body():
+    body = ONESHOT.read_text(encoding="utf-8")
+    assert "code-review.r" in body
+    assert "Code review" in body or "Code Review" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_pipeline_review_wiring.py -k oneshot -v`
+Expected: FAIL — oneshot still contains `@claude` and does not reference the review artifact.
+
+- [ ] **Step 3: Remove the `@claude` marker commit**
+
+In `.claude/skills/oneshot/SKILL.md`, replace the commit step (currently the
+`--allow-empty … @claude` block and its surrounding paragraph, around lines 115–124):
+
+Replace:
+```bash
+git add -A artifacts/feat-{issue_id}    # ensure all generated .md artifacts are staged
+git add -A                              # stage code + everything else
+git commit --allow-empty -m "implement feat-{issue_id} @claude"
+```
+and the following paragraph beginning "The commit message **must end with** `@claude`…"
+
+With:
+```bash
+git add -A artifacts/feat-{issue_id}    # ensure all generated .md artifacts are staged
+git add -A                              # stage code + everything else
+git commit --allow-empty -m "implement feat-{issue_id}"
+```
+and a replacement paragraph:
+> Use `--allow-empty` so this commit always becomes `HEAD`, capturing any
+> remaining artifacts. The whole-branch code review already ran inside the pipeline
+> (see the orchestrator's Code Review phase), so no external review trigger is needed.
+
+- [ ] **Step 4: Append the code-review summary to the PR body**
+
+In `.claude/skills/oneshot/SKILL.md`, in the **Create a pull request** step, extend the
+PR body heredoc so it includes the review. Before building `PR_URL`, read the final
+review artifact:
+
+```bash
+# Most recent code-review artifact (highest revision), if any.
+REVIEW_FILE=$(ls -1 artifacts/feat-{issue_id}/code-review.r*.md 2>/dev/null | sort -V | tail -n1)
+REVIEW_SECTION=""
+if [ -n "$REVIEW_FILE" ]; then
+  REVIEW_SECTION=$(printf '\n## Code review\n\n%s\n' "$(cat "$REVIEW_FILE")")
+fi
+```
+
+Then add `$REVIEW_SECTION` to the end of the PR body. Update the heredoc so it expands
+the variable (use an **unquoted** delimiter `EOF` so substitution happens, and keep the
+`Closes #{issue_id}` line first):
+
+```bash
+PR_URL=$(gh pr create \
+  --base master \
+  --head "$BRANCH" \
+  --label agent \
+  --title "#{issue_id}: implementation" \
+  --body "$(cat <<EOF
+Closes #{issue_id}
+
+## What the issue was
+<description of the feature/problem from the brief>
+
+## How it was fixed / handled
+<summary of the approach and the main changes>
+
+## Artifacts
+- Brief, spec, design, task plan, impl, and review markdown are committed in this branch.
+${REVIEW_SECTION}
+EOF
+)")
+```
+
+Add a sentence under the step noting the `## Code review` section carries the
+pipeline's final review — advisory cleanups and any unresolved correctness findings.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_pipeline_review_wiring.py -v`
+Expected: PASS (all four wiring tests).
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .claude/skills/oneshot/SKILL.md tests/test_pipeline_review_wiring.py
+git commit -m "feat: surface in-pipeline code review on PR, remove @claude trigger"
+```
+
+---
+
+### Task 4: Documentation
+
+Update project docs so the new review stage and state machine are described.
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: nothing. Produces: accurate docs for future maintainers.
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+In `CLAUDE.md`:
+1. In the state-machine diagram and prose, document that after `developing` completes a
+   `code-review` phase runs a whole-branch diff review with a bounded auto-fix loop
+   (reusing `max_revisions`), then the PR is opened.
+2. In the agent list / `.agents/` description, add `code-reviewer.md` — whole-branch
+   diff review (`allowed_tools: [bash, read, grep, glob]`), distinct from the per-task
+   `reviewer.md` (spec-compliance on summaries).
+3. Add `artifacts/{feature_id}/code-review.r{N}.md` to the **Artifact naming** section.
+4. Remove any description that implies diff-level review is delegated to an external
+   `@claude` GitHub Action.
+
+- [ ] **Step 2: Verify no stale `@claude` review references remain in shipped prompts**
+
+Run:
+```bash
+grep -rn "@claude" agentharness/data/ .claude/skills/oneshot/SKILL.md CLAUDE.md
+```
+Expected: no matches (or only matches unrelated to the review trigger — there should be
+none for the review trigger).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document in-pipeline code-review phase and code-reviewer agent"
+```
+
+---
+
+## Manual end-to-end test plan (post-implementation)
+
+The orchestrator/oneshot behavior is prompt-driven and not unit-testable end to end.
+Validate manually on a throwaway issue:
+
+1. Create a small test issue with the `agent` label describing a tiny feature that is
+   easy to implement with an intentional review-worthy choice.
+2. Run `/oneshot <issue#>` and watch the pipeline reach the `code-review` phase.
+3. Confirm `artifacts/feat-<id>/code-review.r1.md` is produced and committed.
+4. If it reports `CHANGES_REQUESTED`, confirm a developer revision round runs and a
+   `code-review.r2.md` follows.
+5. Confirm the opened PR body contains the `## Code review` section and there is **no**
+   `@claude` comment/trigger on the PR.
+
+## Self-Review
+
+- **Spec coverage:** new agent (Task 1) ✓; whole-branch review phase + auto-fix loop +
+  bounded rounds + empty-diff/merge-base/unparseable handling (Task 2) ✓; remove
+  `@claude` + Skip-Review Check, attach review to PR (Tasks 2–3) ✓; checkpoint needs no
+  change (Global Constraints) ✓; docs (Task 4) ✓.
+- **Placeholder scan:** PR body still contains `<description …>` placeholders, but those
+  are pre-existing template tokens the orchestrator fills at runtime, not plan gaps.
+- **Type/name consistency:** the result tokens `CLEAN` / `CHANGES_REQUESTED`, the headers
+  `### Blocking (correctness)` / `### Advisory (cleanup)`, the phase name `code-review`,
+  and the artifact pattern `code-review.r{N}.md` are used identically across Tasks 1–4
+  and both test files.
+```

--- a/docs/superpowers/specs/2026-06-22-in-pipeline-code-review-design.md
+++ b/docs/superpowers/specs/2026-06-22-in-pipeline-code-review-design.md
@@ -1,0 +1,185 @@
+# In-Pipeline Whole-Branch Code Review
+
+**Date:** 2026-06-22
+**Status:** Approved (design)
+
+## Problem
+
+The AgentHarness pipeline has no real review of the **actual code** it writes.
+
+- The per-task `reviewer.md` agent runs with `allowed_tools: []` and only reads the
+  developer's *text summary* (`impl/{task}.md`) against the task spec. It never sees
+  a diff or a source file — it's a spec-compliance gate, not a code review.
+- The only diff-level review is **outsourced to the Claude Code GitHub Action**,
+  triggered by an `@claude` marker commit on the opened PR (`oneshot/SKILL.md`), with
+  the orchestrator's *Skip-Review Check* deferring to it.
+
+We want the pipeline to review its own code internally, before opening the PR, and to
+stop depending on the external `@claude` action.
+
+## Goal
+
+Add a final **whole-branch code-review stage** that runs after all developer tasks
+complete and before the PR is opened. It reviews the entire feature diff vs the base
+branch — the way the CI action reviews a full PR — and uses its findings to drive a
+bounded auto-fix loop. The external `@claude` review is removed.
+
+## Approach (chosen)
+
+- **Scope:** a single final review of `git diff (merge-base master HEAD)...HEAD`
+  (option B), not a per-task code review.
+- **Disposition:** block + bounded auto-fix loop (option A), reusing the existing
+  developer-revision machinery.
+- **Criteria:** the `/code-review` skill philosophy (option B) — **correctness bugs**
+  plus **reuse / simplification / efficiency** cleanups, high-confidence findings only,
+  no style nits.
+
+Finding-to-disposition mapping (falls straight out of the criteria split):
+
+| Bucket | Disposition |
+|--------|-------------|
+| Correctness bugs | **Blocking** → trigger a developer fix round |
+| Reuse / simplification / efficiency cleanups | **Advisory** → recorded + attached to PR, never block |
+
+## Components
+
+### 1. New agent — `agentharness/data/agents/code-reviewer.md`
+
+Distinct from the per-task `reviewer.md`, which is **left unchanged**.
+
+Frontmatter:
+
+```yaml
+id: code-reviewer
+display_name: "Code Reviewer Agent"
+model: claude-sonnet-4-6        # reads real code; needs a strong model
+phase: code-review
+max_turns: 30
+allowed_tools: [bash, read, grep, glob]   # MUST inspect real code, not a summary
+output_format: markdown
+visibility_timeout: 1800
+retry_limit: 2
+output_parsing: none            # orchestrator parses the result line itself
+```
+
+System prompt embodies the `/code-review` philosophy and emits a parseable result:
+
+```
+## Review Result: CLEAN | CHANGES_REQUESTED
+
+### Blocking (correctness)
+- `path/to/file.py:42` — <bug + why it is wrong>
+
+### Advisory (cleanup)
+- `path/to/file.py:88` — <reuse / simplification / efficiency suggestion>
+```
+
+Rules baked into the prompt:
+- Report only **high-confidence** findings. When unsure, omit.
+- Only **correctness** issues go under *Blocking*. Everything else is *Advisory*.
+- `CHANGES_REQUESTED` **iff** there is at least one Blocking finding; otherwise `CLEAN`.
+- No style/formatting nits, no speculative "could also" suggestions.
+- It receives the diff and may `read`/`grep` the wider tree for context.
+
+### 2. Orchestrator — new **Code Review phase**
+
+Added to `agentharness/data/claude-agents/orchestrator.md`, in the **Completion**
+section, after `developing` is marked `completed` and before handoff to PR creation.
+
+Round count `N` is derived from existing `code-review.r{N}.md` artifacts (no new
+checkpoint field). Bounded by the checkpoint's existing `max_revisions` (default 3).
+
+Loop:
+
+1. `agentharness checkpoint phase feat-{id} code-review in_progress`.
+2. Compute the diff:
+   `git diff $(git merge-base master HEAD)...HEAD` (capture to a temp file / pass inline).
+3. Spawn the code-reviewer Task: system prompt from `code-reviewer.md` + the diff +
+   `spec.r1.md` for intent. Instruct it to write `artifacts/feat-{id}/code-review.r{N}.md`.
+4. Commit + hard-verify the artifact (same strict-persistence pattern as every other
+   artifact).
+5. Parse the `## Review Result:` line.
+   - **CLEAN** (or only Advisory): `checkpoint phase feat-{id} code-review completed`.
+     Continue to PR.
+   - **CHANGES_REQUESTED** and `N < max_revisions`: write a synthetic review-fix task
+     context from the Blocking findings, spawn a **developer revision round** against it
+     (developer already works in-place on the current branch), commit its work, then
+     loop back to step 2 with `N+1`.
+   - **CHANGES_REQUESTED** and `N >= max_revisions`: `checkpoint phase feat-{id}
+     code-review completed` (do not fail the whole feature), and carry the unresolved
+     Blocking findings forward so they are appended to the PR body. Work is never lost.
+
+### 3. Remove the external `@claude` review
+
+- `oneshot/SKILL.md`: drop the `@claude` marker commit (the `--allow-empty … @claude`
+  step). The final commit no longer needs a trigger phrase.
+- `orchestrator.md`: remove the **Skip-Review Check** (it existed only to defer to the
+  CI action; with no `@claude`, the per-task reviewer simply always runs as intended —
+  restoring the design's original behavior). Update the impl-artifact commit ordering
+  notes that referenced the skip check.
+- `oneshot/SKILL.md` PR body: in place of the `@claude` trigger, append the final
+  code-review summary — the **Advisory** findings and any unresolved **Blocking**
+  findings from `code-review.r{N}.md` — so a human reviewer still sees them on the PR.
+
+### 4. Checkpoint — no code change required
+
+`update_phase` accepts an arbitrary phase string, so `code-review` is a valid phase
+with no model/CLI change. `checkpoint status` is unchanged (it returns `complete` once
+tasks finish; the orchestrator drives the code-review phase explicitly from there). The
+round counter is the `code-review.r{N}.md` file count, bounded by `max_revisions`.
+
+## Artifacts (new)
+
+```
+artifacts/feat-{id}/code-review.r{N}.md      # whole-branch review, per round
+```
+
+## Data flow
+
+```
+developing completed
+        │
+        ▼
+  git diff (merge-base master HEAD)...HEAD
+        │
+        ▼
+  code-reviewer Task ──► code-review.r{N}.md ──► commit
+        │
+        ├─ CLEAN / advisory-only ───────────────► PR (with advisory notes)
+        │
+        └─ CHANGES_REQUESTED, N < max ──► developer revision round
+                                              │
+                                              ▼   (re-diff, N+1)
+                                          loop to review
+        │
+        └─ CHANGES_REQUESTED, N >= max ─► PR (unresolved blocking notes attached)
+```
+
+## Error handling
+
+- Review agent produces no/garbled `## Review Result:` line → treat as `CLEAN` is unsafe;
+  instead retry the review Task once (`retry_limit: 2`), then on continued failure mark
+  the round CLEAN with a recorded warning in the artifact so the pipeline still completes
+  (never hard-block the feature on a flaky reviewer).
+- Empty diff (no code changed) → skip the review phase, mark `code-review completed`.
+- `git merge-base` failure (shallow/unrelated history) → fall back to `git diff master...HEAD`.
+
+## Testing
+
+- **Unit (Python):** the only Python change is potentially a small diff/round helper if
+  we add one to the CLI; if the loop stays entirely in the orchestrator markdown, the
+  Python surface is unchanged and existing `test_*` suites must still pass. Add a unit
+  test for any new helper (e.g. computing the next review round from existing artifacts).
+- **Agent-definition test:** assert `code-reviewer.md` parses (valid frontmatter, required
+  fields) the same way other agent defs are validated.
+- **Orchestrator behavior** is markdown-driven and exercised by a manual end-to-end
+  `/oneshot` run on a throwaway issue; document the manual test plan in the PR.
+
+## Out of scope (YAGNI)
+
+- Per-task code review (rejected in favor of B).
+- Posting inline PR review comments via the GitHub API (advisory findings go in the PR
+  body, not as line comments).
+- Configurable effort levels (`low/medium/high`) — fixed at the high-confidence default.
+- Changing the per-task `reviewer.md`.
+```

--- a/tests/test_code_reviewer_agent.py
+++ b/tests/test_code_reviewer_agent.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from agentharness.prompt_builder import load_agent_definition
+
+AGENT_PATH = Path("agentharness/data/agents/code-reviewer.md")
+
+
+def test_code_reviewer_agent_parses_with_runtime_fields():
+    agent = load_agent_definition(AGENT_PATH)
+
+    assert agent.id == "code-reviewer"
+    assert agent.phase == "code-review"
+    # Must be able to read real code, not just a text summary.
+    assert agent.allowed_tools is not None
+    assert "read" in agent.allowed_tools
+    assert "bash" in agent.allowed_tools
+    # Orchestrator parses the result itself; no built-in parser.
+    assert agent.output_parsing == "none"
+    assert agent.system_prompt.strip() != ""
+
+
+def test_code_reviewer_prompt_defines_parseable_result_contract():
+    body = AGENT_PATH.read_text(encoding="utf-8")
+
+    # The exact tokens the orchestrator greps for must be present.
+    assert "## Review Result: CLEAN | CHANGES_REQUESTED" in body
+    assert "### Blocking (correctness)" in body
+    assert "### Advisory (cleanup)" in body

--- a/tests/test_pipeline_review_wiring.py
+++ b/tests/test_pipeline_review_wiring.py
@@ -17,3 +17,17 @@ def test_orchestrator_no_longer_skips_review_on_at_claude():
     # The Skip-Review Check and its @claude trigger must be gone.
     assert "Skip-Review Check" not in body
     assert "@claude" not in body
+
+
+ONESHOT = Path(".claude/skills/oneshot/SKILL.md")
+
+
+def test_oneshot_skill_drops_at_claude_trigger():
+    body = ONESHOT.read_text(encoding="utf-8")
+    assert "@claude" not in body
+
+
+def test_oneshot_skill_attaches_code_review_to_pr_body():
+    body = ONESHOT.read_text(encoding="utf-8")
+    assert "code-review.r" in body
+    assert "Code review" in body or "Code Review" in body

--- a/tests/test_pipeline_review_wiring.py
+++ b/tests/test_pipeline_review_wiring.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+ORCHESTRATOR = Path("agentharness/data/claude-agents/orchestrator.md")
+
+
+def test_orchestrator_defines_code_review_phase():
+    body = ORCHESTRATOR.read_text(encoding="utf-8")
+    assert "## Code Review phase" in body
+    assert "code-review.r{N}.md" in body
+    assert "merge-base master HEAD" in body
+    # Reads the new agent.
+    assert ".agents/code-reviewer.md" in body
+
+
+def test_orchestrator_no_longer_skips_review_on_at_claude():
+    body = ORCHESTRATOR.read_text(encoding="utf-8")
+    # The Skip-Review Check and its @claude trigger must be gone.
+    assert "Skip-Review Check" not in body
+    assert "@claude" not in body


### PR DESCRIPTION
Adds a final whole-branch code-review stage to the pipeline: after all developer tasks pass per-task review, the orchestrator diffs the feature branch against its merge-base with `master` and hands it to a new `code-reviewer` agent that inspects the real code (not just the developer's text summary). Correctness findings block and trigger a bounded developer fix loop (capped by `max_revisions`), while reuse/simplification/efficiency findings are advisory and attached to the PR body. This replaces the external `@claude` GitHub Action review — the `@claude` marker commit and the orchestrator's Skip-Review Check are removed. Docs (`CLAUDE.md`, chopchop/oneshot skills) and the design spec + implementation plan are included, with regression tests covering the new agent definition and the orchestrator/oneshot wiring.
