### PR TITLE
feat: enforce agent label and Closes link on harness PRs

### DIFF
--- a/.claude/skills/oneshot/SKILL.md
+++ b/.claude/skills/oneshot/SKILL.md
@@ -140,9 +140,12 @@ git push -u origin "$BRANCH"
    feature PR without it.
 
    Open the PR (base = the repository default branch, head = `$BRANCH`). Capture
-   the PR URL and attach the `agent` label in a **separate, explicit step** — do
-   not rely on `--label` on `gh pr create` alone, as it is sometimes silently
-   dropped. The `gh pr edit --add-label` call is the guarantee.
+   the PR URL, then run `scripts/ensure_pr_linked.sh "$PR_URL" "{issue_id}"` — this
+   is the guarantee for **both** requirements above. Do not rely on `--label` or the
+   `Closes` template line on `gh pr create` alone; the LLM-filled body and the
+   `--label` flag are both sometimes dropped. The script adds the `agent` label,
+   injects `Closes #{issue_id}` if missing, then hard-fails if it cannot confirm
+   either.
 
    First capture the pipeline's final code review so it can be surfaced on the PR.
    The `## Code review` section carries the whole-branch review run inside the
@@ -175,10 +178,9 @@ ${REVIEW_SECTION}
 EOF
 )")
 
-# MANDATORY: guarantee the label is attached. Verify it actually landed.
-gh pr edit "$PR_URL" --add-label agent
-gh pr view "$PR_URL" --json labels --jq '.labels[].name' | grep -qx agent \
-  || { echo "ERROR: agent label missing on $PR_URL" >&2; exit 1; }
+# MANDATORY: guarantee the `agent` label AND the `Closes #{issue_id}` link.
+# Auto-repairs both if the agent dropped them, then hard-fails if it cannot.
+scripts/ensure_pr_linked.sh "$PR_URL" "{issue_id}"
 ```
    Substitute the real GitHub issue number for `{issue_id}` in both the title
    and the `Closes #{issue_id}` line (same number used for `ISSUE_ID` above).

--- a/scripts/ensure_pr_linked.sh
+++ b/scripts/ensure_pr_linked.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Ensure a harness-opened PR is tied to its tracking issue.
+#
+# Guarantees, idempotently, that the pull request:
+#   1. carries the `agent` label, and
+#   2. links the issue with a closing keyword (`Closes #<n>`) so merging the PR
+#      auto-closes the issue.
+#
+# Auto-repairs first (adds the label / injects a `Closes #<n>` line), then
+# verifies. Exits non-zero if it still cannot guarantee both.
+#
+# Usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>
+set -euo pipefail
+
+PR="${1:-}"
+ISSUE="${2:-}"
+
+if [[ -z "$PR" || -z "$ISSUE" ]]; then
+  echo "usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>" >&2
+  exit 2
+fi
+
+if [[ ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: issue number must be numeric, got: $ISSUE" >&2
+  exit 2
+fi
+
+# GitHub closing keywords, immediately followed by `#<issue>` and a non-digit
+# boundary (so `#1` does not match `#10`).
+CLOSE_LINK="(clos(e|es|ed)|fix(es|ed)?|resolve(s|d)?) +#${ISSUE}([^0-9]|\$)"
+
+# 1. Guarantee the `agent` label (idempotent add, then verify it landed).
+gh pr edit "$PR" --add-label agent
+if ! gh pr view "$PR" --json labels --jq '.labels[].name' | grep -qx agent; then
+  echo "ERROR: agent label missing on $PR" >&2
+  exit 1
+fi
+
+# 2. Guarantee a closing link to the issue (inject if absent, preserving body).
+body=$(gh pr view "$PR" --json body --jq '.body')
+if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
+  printf -v new_body 'Closes #%s\n\n%s' "$ISSUE" "$body"
+  gh pr edit "$PR" --body "$new_body"
+  body=$(gh pr view "$PR" --json body --jq '.body')
+  if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
+    echo "ERROR: failed to add Closes #${ISSUE} to $PR" >&2
+    exit 1
+  fi
+fi
+
+echo "PR $PR linked to issue #$ISSUE with agent label."

--- a/tests/test_ensure_pr_linked.py
+++ b/tests/test_ensure_pr_linked.py
@@ -1,0 +1,145 @@
+"""Tests for scripts/ensure_pr_linked.sh.
+
+The real bash script is driven through a fake `gh` placed on PATH. The stub keeps
+PR state (labels + body) in a JSON file across the multiple `gh` calls a single
+script run makes, so we can assert end-to-end behaviour without touching GitHub.
+"""
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "ensure_pr_linked.sh"
+
+# A fake `gh` that mutates/reads a JSON state file given via $GH_FAKE_STATE.
+FAKE_GH = '''#!/usr/bin/env python3
+import json, os, sys
+
+state_path = os.environ["GH_FAKE_STATE"]
+with open(state_path) as fh:
+    state = json.load(fh)
+args = sys.argv[1:]
+state.setdefault("calls", []).append(args)
+
+def save():
+    with open(state_path, "w") as fh:
+        json.dump(state, fh)
+
+if args[:2] == ["pr", "edit"]:
+    if "--add-label" in args:
+        label = args[args.index("--add-label") + 1]
+        if not state.get("label_wont_land") and label not in state["labels"]:
+            state["labels"].append(label)
+    if "--body" in args:
+        state["body"] = args[args.index("--body") + 1]
+    save()
+    sys.exit(0)
+
+if args[:2] == ["pr", "view"]:
+    save()
+    if "labels" in args:
+        print("\\n".join(state["labels"]))
+    elif "body" in args:
+        print(state["body"])
+    sys.exit(0)
+
+save()
+sys.exit(0)
+'''
+
+
+@pytest.fixture
+def run_script(tmp_path):
+    """Return a callable that runs the script with a fake `gh` and given state."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(FAKE_GH, encoding="utf-8")
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    state_path = tmp_path / "state.json"
+
+    def _run(pr, issue, *, labels=None, body="", label_wont_land=False):
+        state = {
+            "labels": list(labels or []),
+            "body": body,
+            "label_wont_land": label_wont_land,
+            "calls": [],
+        }
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+        env["GH_FAKE_STATE"] = str(state_path)
+
+        proc = subprocess.run(
+            ["bash", str(SCRIPT), pr, issue],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        final_state = json.loads(state_path.read_text(encoding="utf-8"))
+        return proc, final_state
+
+    return _run
+
+
+def test_adds_agent_label_when_missing(run_script):
+    proc, state = run_script("42", "7", labels=[], body="Closes #7")
+
+    assert proc.returncode == 0, proc.stderr
+    assert "agent" in state["labels"]
+
+
+def test_label_add_is_idempotent_when_already_present(run_script):
+    proc, state = run_script("42", "7", labels=["agent"], body="Closes #7")
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["labels"].count("agent") == 1
+
+
+def test_injects_closes_when_missing_preserving_body(run_script):
+    original = "## What\nSome detail\n\n## Code review\nlooks good"
+    proc, state = run_script("42", "7", labels=["agent"], body=original)
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["body"].startswith("Closes #7")
+    # Existing body content is preserved beneath the injected link.
+    assert original in state["body"]
+
+
+def test_leaves_body_untouched_when_link_present(run_script):
+    for body in ("Closes #7", "fixes #7", "This resolves #7 nicely"):
+        proc, state = run_script("42", "7", labels=["agent"], body=body)
+        assert proc.returncode == 0, proc.stderr
+        assert state["body"] == body
+
+
+def test_does_not_treat_superset_issue_number_as_link(run_script):
+    # Body references #70, but the tracking issue is #7 — must still inject.
+    proc, state = run_script("42", "7", labels=["agent"], body="Closes #70")
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["body"].startswith("Closes #7\n")
+
+
+def test_rejects_non_numeric_issue(run_script):
+    proc, _ = run_script("42", "abc", labels=["agent"], body="")
+
+    assert proc.returncode == 2
+    assert "numeric" in proc.stderr
+
+
+def test_hard_fails_when_label_cannot_land(run_script):
+    proc, _ = run_script("42", "7", labels=[], body="Closes #7", label_wont_land=True)
+
+    assert proc.returncode == 1
+    assert "agent label missing" in proc.stderr
+
+
+def test_script_exists_and_is_executable():
+    assert SCRIPT.exists()
+    assert os.access(SCRIPT, os.X_OK), "scripts/ensure_pr_linked.sh must be executable"

--- a/tests/test_pipeline_review_wiring.py
+++ b/tests/test_pipeline_review_wiring.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 ORCHESTRATOR = Path("agentharness/data/claude-agents/orchestrator.md")
@@ -31,3 +32,16 @@ def test_oneshot_skill_attaches_code_review_to_pr_body():
     body = ONESHOT.read_text(encoding="utf-8")
     assert "code-review.r" in body
     assert "Code review" in body or "Code Review" in body
+
+
+ENSURE_PR_LINKED = Path("scripts/ensure_pr_linked.sh")
+
+
+def test_oneshot_skill_invokes_ensure_pr_linked():
+    body = ONESHOT.read_text(encoding="utf-8")
+    assert "scripts/ensure_pr_linked.sh" in body
+
+
+def test_ensure_pr_linked_script_exists_and_is_executable():
+    assert ENSURE_PR_LINKED.exists()
+    assert os.access(ENSURE_PR_LINKED, os.X_OK)


### PR DESCRIPTION
Adds `scripts/ensure_pr_linked.sh`, a deterministic post-PR step that guarantees a harness-opened PR carries the `agent` label and a `Closes #<n>` link, auto-repairing both then hard-failing if it can't. It's wired into the `oneshot` skill (replacing the label-only inline check that left the issue link unverified) and into the global `finishfeature` skill, guarded so it's a no-op outside harness repos. New unit tests drive the script through a fake `gh` covering label add/idempotency, `Closes` injection while preserving the body, the `#7`≠`#70` boundary, non-numeric rejection, and the label-cannot-land hard-fail; skill-wiring assertions confirm the script is referenced and executable.