### PR TITLE
fix: ship init skills as real files instead of a symlink

### DIFF
--- a/agentharness/data/skills
+++ b/agentharness/data/skills
@@ -1,1 +1,0 @@
-../../.claude/skills

--- a/agentharness/data/skills/azure-storage/SKILL.md
+++ b/agentharness/data/skills/azure-storage/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: azure-storage
+description: Manage Azure Blob Storage and Azure Storage Queues for AgentHarness. Use for initial setup, inspecting pipeline artifacts, debugging queue messages, and managing dead-letter queues. Trigger on: "setup azure", "create queues", "list blobs", "check queue", "dead letter", "inspect artifact", "azure storage".
+---
+
+You manage Azure Blob Storage and Azure Storage Queues using the `az` CLI.
+
+The connection string is read from the `.env` file in the project root. Before running any `az storage` command, load the `.env` file:
+
+```bash
+set -a && source .env && set +a
+```
+
+Always pass `--connection-string "$AZURE_STORAGE_CONNECTION_STRING"` to every `az storage` command.
+
+---
+
+## Pipeline config
+
+`.pipeline/config.json` controls the storage account, container name, and pipeline behaviour. Edit it directly or use the snippets below.
+
+### Show current config
+```bash
+cat .pipeline/config.json
+```
+
+### Change the blob container name
+```bash
+python3 -c "
+import json, pathlib
+p = pathlib.Path('.pipeline/config.json')
+cfg = json.loads(p.read_text())
+cfg['storage']['container'] = 'YOUR_CONTAINER_NAME'
+p.write_text(json.dumps(cfg, indent=2))
+"
+```
+
+### Adjust pipeline timeouts / limits
+```bash
+python3 -c "
+import json, pathlib
+p = pathlib.Path('.pipeline/config.json')
+cfg = json.loads(p.read_text())
+cfg['defaults']['dead_letter_threshold'] = 3   # retries before dead-letter
+cfg['defaults']['max_revisions'] = 3           # review→dev revision rounds
+cfg['defaults']['poll_interval_seconds'] = 1.0 # worker poll cadence
+p.write_text(json.dumps(cfg, indent=2))
+"
+```
+
+> The `connection_string_env` key is the **name** of the env var (`AZURE_STORAGE_CONNECTION_STRING`), not the value — set the actual value in `.env`.
+
+---
+
+## Initial setup
+
+Create the blob container and all pipeline queues:
+
+```bash
+# Blob container
+az storage container create \
+  --name pipeline-artifacts \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+
+# Queues
+for q in planner-queue architect-queue designer-queue developer-queue review-queue; do
+  az storage queue create --name "$q" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+done
+```
+
+---
+
+## Blob Storage
+
+### List all features (top-level artifact folders)
+```bash
+az storage blob list \
+  --container-name pipeline-artifacts \
+  --prefix "artifacts/" \
+  --delimiter "/" \
+  --query "[].name" \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  -o tsv
+```
+
+### List artifacts for a specific feature
+```bash
+az storage blob list \
+  --container-name pipeline-artifacts \
+  --prefix "artifacts/{feature_id}/" \
+  --query "[].{name:name, size:properties.contentLength, modified:properties.lastModified}" \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  -o table
+```
+
+### Download and display an artifact
+```bash
+az storage blob download \
+  --container-name pipeline-artifacts \
+  --name "artifacts/{feature_id}/brief.md" \
+  --file /dev/stdout \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  2>/dev/null
+```
+
+### Download state.json for a feature
+```bash
+az storage blob download \
+  --container-name pipeline-artifacts \
+  --name "artifacts/{feature_id}/state.json" \
+  --file /dev/stdout \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  2>/dev/null | python3 -m json.tool
+```
+
+### Upload a file
+```bash
+az storage blob upload \
+  --container-name pipeline-artifacts \
+  --name "artifacts/{feature_id}/brief.md" \
+  --file ./brief.md \
+  --overwrite \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+```
+
+### Delete all artifacts for a feature
+```bash
+az storage blob delete-batch \
+  --source pipeline-artifacts \
+  --pattern "artifacts/{feature_id}/*" \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+```
+
+---
+
+## Storage Queues
+
+### Check message count on all queues
+```bash
+for q in planner-queue architect-queue designer-queue developer-queue review-queue; do
+  count=$(az storage queue show --name "$q" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+    --query "approximateMessageCount" -o tsv 2>/dev/null || echo "?")
+  echo "$q: $count"
+done
+```
+
+### Peek at messages in a queue (non-destructive)
+```bash
+az storage message peek \
+  --queue-name {queue_name} \
+  --num-messages 5 \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  -o table
+```
+
+### Decode a queue message (messages are base64-encoded JSON)
+```bash
+az storage message peek \
+  --queue-name {queue_name} \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  --query "[0].content" -o tsv | base64 -d | python3 -m json.tool
+```
+
+### Clear all messages from a queue
+```bash
+az storage message clear \
+  --queue-name {queue_name} \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+```
+
+### Manually enqueue a message (for testing)
+```bash
+az storage message put \
+  --queue-name planner-queue \
+  --content "$(echo '{
+    "feature_id": "feat-test",
+    "task_id": "feat-test-planning-1",
+    "input_artifacts": ["artifacts/feat-test/brief.md"],
+    "output_artifact": "artifacts/feat-test/spec.r1.md",
+    "agent_role": "planner",
+    "context": null,
+    "revision": 1,
+    "review_feedback": null
+  }' | base64)" \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+```
+
+---
+
+## Dead-letter queues
+
+Dead-letter queues are named `{queue-name}-poison`.
+
+### Check dead-letter queues for failed tasks
+```bash
+for q in planner-queue-poison architect-queue-poison designer-queue-poison developer-queue-poison review-queue-poison; do
+  count=$(az storage queue show --name "$q" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+    --query "approximateMessageCount" -o tsv 2>/dev/null)
+  [ -n "$count" ] && [ "$count" -gt 0 ] && echo "$q: $count failed messages"
+done
+```
+
+### Inspect a dead-letter message
+```bash
+az storage message peek \
+  --queue-name {queue_name}-poison \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  --query "[0].content" -o tsv | base64 -d | python3 -m json.tool
+```
+
+### Re-queue a dead-letter message (after fixing the issue)
+```bash
+# 1. Get the message
+MSG=$(az storage message get \
+  --queue-name {queue_name}-poison \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  --query "[0]" -o json)
+
+CONTENT=$(echo "$MSG" | python3 -c "import sys,json; print(json.load(sys.stdin)['content'])")
+ID=$(echo "$MSG" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+RECEIPT=$(echo "$MSG" | python3 -c "import sys,json; print(json.load(sys.stdin)['popReceipt'])")
+
+# 2. Put it back in the original queue
+az storage message put \
+  --queue-name {queue_name} \
+  --content "$CONTENT" \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+
+# 3. Delete from dead-letter
+az storage message delete \
+  --queue-name {queue_name}-poison \
+  --id "$ID" \
+  --pop-receipt "$RECEIPT" \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+```
+
+---
+
+## Common patterns
+
+### Full pipeline health check
+```bash
+echo "=== Queues ===" && \
+for q in planner-queue architect-queue designer-queue developer-queue review-queue; do
+  count=$(az storage queue show --name "$q" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+    --query "approximateMessageCount" -o tsv 2>/dev/null || echo "MISSING")
+  echo "  $q: $count"
+done && \
+echo "=== Dead-letter ===" && \
+for q in planner-queue architect-queue designer-queue developer-queue review-queue; do
+  count=$(az storage queue show --name "${q}-poison" \
+    --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+    --query "approximateMessageCount" -o tsv 2>/dev/null || echo "0")
+  [ "$count" != "0" ] && echo "  ${q}-poison: $count FAILED MESSAGES" || true
+done
+
+echo "=== Active features ===" && \
+az storage blob list \
+  --container-name pipeline-artifacts \
+  --prefix "artifacts/" \
+  --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+  --query "[?ends_with(name, '/state.json')].name" \
+  -o tsv | sed 's|artifacts/||;s|/state.json||'
+```

--- a/agentharness/data/skills/brainstorm/SKILL.md
+++ b/agentharness/data/skills/brainstorm/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: brainstorm
+description: Start an interactive brainstorm session to define a new feature brief and submit it to the agentic development pipeline. Use when the user wants to create a new feature, has a new idea, or says "brainstorm", "new feature", "let's build".
+---
+
+You are a product discovery assistant helping define a feature brief for the AgentHarness autonomous development pipeline.
+
+Your goal: through conversation, understand the feature thoroughly, then write `brief.md` and submit it to the pipeline.
+
+## Process
+
+**Phase 1 — Discovery (conversation)**
+
+Ask focused questions to understand:
+- What problem does this solve? For whom?
+- What should it do (functional requirements)?
+- What constraints exist (tech stack, existing integrations, scale)?
+- What's explicitly out of scope?
+- How do we measure success?
+
+Ask 1-2 questions at a time, not a full list. Listen and dig deeper. When you have a solid understanding, move to Phase 2.
+
+**Phase 2 — Write brief.md**
+
+Write the brief using the Write tool to `brief.md` in the current working directory:
+
+```markdown
+# Feature Brief: {feature name}
+
+## Problem Statement
+{What problem this solves and for whom}
+
+## Goals
+- {Specific, measurable goal}
+
+## Functional Requirements
+- {What the system must do}
+
+## Non-Functional Requirements
+- {Performance, security, reliability expectations}
+
+## Technical Constraints
+- {Existing tech stack, integrations, boundaries}
+
+## Out of Scope
+- {Explicitly excluded items}
+
+## Success Criteria
+- {How we measure success}
+
+## Additional Context
+{Any other relevant background}
+```
+
+**Phase 3 — Review and upload**
+
+Show the user a summary of what you wrote. Ask: "Does this capture what you had in mind, or would you like to adjust anything?"
+
+If they're satisfied, upload the brief:
+```bash
+agentharness submit brief.md
+```
+
+This uploads the brief and returns a **feature ID**. Tell the user:
+- The feature ID (e.g. `feat-20260425-abc123`)
+- They can review/edit `brief.md` further before starting the pipeline
+- When ready to start: run `/oneshot <issue-number>` to start the pipeline
+
+## Tone
+
+Be concise and curious. You're a smart colleague helping think through a feature — not a form to fill out. The conversation should feel natural, not like an interrogation.

--- a/agentharness/data/skills/chopchop/SKILL.md
+++ b/agentharness/data/skills/chopchop/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: chopchop
+description: Stop loafing and pick up the next piece of work. Finds the oldest open GitHub issue labelled `agent` that has no PR yet and runs the oneshot pipeline on it. Use when the user says "chopchop", "do some work", "get to work", "next issue", "pick up the next task", or otherwise tells the harness to stop being lazy and ship something.
+---
+
+You are the "get off your ass and do work" skill. Your job: find the single
+oldest open issue that still needs work, then kick off the `oneshot` pipeline on
+it. No feature ID required from the user — you go find the work yourself.
+
+## What you do
+
+1. **List candidate issues.** Get all open issues labelled `agent`, oldest
+   first, using the `gh` CLI:
+```bash
+gh issue list --label agent --state open --json number,title,createdAt \
+  --limit 200 --search "sort:created-asc"
+```
+   If the list is empty, tell the user there's nothing to do ("No `agent` issues
+   waiting — you're all caught up.") and stop.
+
+2. **Find the oldest one without a PR.** Walk the list from oldest to newest. For
+   each issue number `N`, the oneshot pipeline uses a branch named
+   `feature/{N}-{slug}`, so check whether any PR's head branch starts with
+   `feature/{N}-`:
+```bash
+gh pr list --state all --json number,headRefName \
+  --jq "[.[] | select(.headRefName | startswith(\"feature/${N}-\"))] | length"
+```
+   - If the result is `0`, this issue has **no PR** — it's your target. Stop
+     walking.
+   - If the result is `>= 1`, a PR already exists; skip this issue and move to
+     the next-oldest.
+
+   If every `agent` issue already has a PR, tell the user there's nothing left to
+   start ("Every `agent` issue already has a PR open.") and stop.
+
+3. **Announce the pick.** Print which issue you selected, e.g.
+   `Picking up the oldest unstarted issue: #{N} — {title}`.
+
+4. **Run oneshot on it.** Invoke the `oneshot` skill on the selected issue
+   number — this drives the full pipeline (worktree on `feature/{N}-{slug}`,
+   label lifecycle `agent` → `agent-wip` → `agent-completed`, tests, in-pipeline
+   code review, push, and the `agent`-labelled PR):
+```
+/oneshot {N}
+```
+   Follow the oneshot skill's instructions end to end; do not duplicate its
+   steps here.
+
+## Notes
+
+- Only **one** issue is picked per invocation — the oldest eligible one. Run the
+  skill again to grab the next.
+- "Oldest" is by issue creation time (`createdAt`), ascending.
+- The PR check keys off the `feature/{N}-{slug}` branch convention that
+  `oneshot` uses (matched by the `feature/{N}-` prefix). An issue that's
+  mid-flight will already have a PR (or be labelled `agent-wip`, which removes
+  its `agent` label), so it won't be picked again.

--- a/agentharness/data/skills/convertforagent/SKILL.md
+++ b/agentharness/data/skills/convertforagent/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: convertforagent
+description: Convert an existing GitHub issue into an AgentHarness feature. Patches the issue in-place — adds agentharness-feature + feat:brainstormed labels and appends state JSON to the body. Detects GitHub sub-issue relationships and sets up epic branches automatically. Does NOT create a new issue. Usage: /convertforagent <issue-number>
+---
+
+# Convert GitHub Issue to AgentHarness Feature
+
+Patches an existing GitHub issue so it becomes a harness-tracked feature in `brainstormed` state — identical to what `agentharness submit` produces, but the original issue is updated in-place instead of a new one being created. If the issue is a GitHub sub-issue of an epic, the epic branch is created automatically and this child branches off it.
+
+## Steps
+
+### 1. Load environment
+
+```bash
+set -a && source .env && set +a
+```
+
+### 2. Run the conversion
+
+Replace `<issue-number>` with the actual issue number:
+
+```bash
+agentharness convert <issue-number>
+```
+
+### 3. Verify discoverability
+
+```bash
+agentharness list 2>/dev/null | grep feat-
+```
+
+### 4. Report to user
+
+Tell the user:
+- The **feature ID** printed by the command
+- That the feature is now visible in `agentharness watch`
+- Next command: run `/oneshot <issue-number>` to start the pipeline
+
+## What the command does
+
+| Action | Details |
+|--------|---------|
+| Fetches issue title | Used to derive `feat-<slug>` feature ID (40 char max) |
+| Detects epic parent | Calls GitHub sub-issues API + body-marker fallback (`Epic: #N`) |
+| Creates branches | `epic-<slug>` off main (once, idempotent), then `feat-<slug>` off epic branch |
+| Opens umbrella PR | Draft `epic-<slug> → main` PR with sub-issue checklist (idempotent) |
+| Uploads brief | `artifacts/<feature-id>/brief.md` — original issue body |
+| Patches issue body | Appends/replaces `\`\`\`agentharness-state` block |
+| Adds labels | `agentharness-feature` + `feat:brainstormed` |
+
+## Notes
+
+- If the issue body already contains an `agentharness-state` block it is replaced, not duplicated.
+- For epic children, the `feat-<slug>` branch is created off the epic branch, not main.
+- Requires `GITHUB_TOKEN` in `.env` and a working `gh` CLI session.

--- a/agentharness/data/skills/github-storage/SKILL.md
+++ b/agentharness/data/skills/github-storage/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: github-storage
+description: Manage GitHub Issues, branches, and artifacts for AgentHarness GitHub backend. Use for inspecting pipeline queues (issues), listing features, checking dead-letter issues, uploading briefs, and inspecting feature state. Trigger on: "setup github", "list issues", "check queue", "dead letter", "inspect artifact", "github storage", "github backend".
+---
+
+You manage the AgentHarness GitHub backend using the `gh` CLI.
+
+The GitHub backend uses:
+- **GitHub Issues** (with labels) as the work queue
+- **Git branches** (`feat/{feature_id}`) as the artifact store
+- **Issue labels + JSON body** as the feature state manager
+
+Load the `.env` file before running any commands that need `GITHUB_TOKEN`:
+
+```bash
+set -a && source .env && set +a
+```
+
+The repository is auto-detected from the git remote, or set explicitly via `GITHUB_OWNER` and `GITHUB_RUNS_REPO` in `.env`.
+
+---
+
+## Pipeline config
+
+`.pipeline/config.json` controls the backend and pipeline behaviour. Edit it directly or use the snippets below.
+
+### Show current config
+```bash
+cat .pipeline/config.json
+```
+
+### Switch to GitHub backend
+```bash
+python3 -c "
+import json, pathlib
+p = pathlib.Path('.pipeline/config.json')
+cfg = json.loads(p.read_text())
+cfg['storage_backend'] = 'github'
+p.write_text(json.dumps(cfg, indent=2))
+"
+```
+
+### Adjust pipeline timeouts / limits
+```bash
+python3 -c "
+import json, pathlib
+p = pathlib.Path('.pipeline/config.json')
+cfg = json.loads(p.read_text())
+cfg['defaults']['dead_letter_threshold'] = 3   # retries before dead-letter
+cfg['defaults']['max_revisions'] = 3           # review→dev revision rounds
+cfg['defaults']['poll_interval_seconds'] = 5.0 # observer poll cadence
+p.write_text(json.dumps(cfg, indent=2))
+"
+```
+
+---
+
+## Initial setup
+
+The GitHub backend requires no queue creation — issues are created dynamically. You only need a valid `GITHUB_TOKEN` and the correct repo set in `.env`.
+
+### Verify credentials and repo access
+```bash
+gh auth status
+gh repo view
+```
+
+### Create required issue labels (first-time setup)
+```bash
+# Feature status labels
+for label in feat:brainstorming feat:analyzing feat:architecting feat:designing feat:planning feat:developing feat:reviewing feat:dev_revision feat:done feat:failed; do
+  gh label create "$label" --color "#0075ca" --force
+done
+
+# Task state labels
+for label in state:queued state:in-progress state:completed state:failed state:dead-letter state:blocked; do
+  gh label create "$label" --color "#e4e669" --force
+done
+
+# Queue routing labels
+for label in queue:analyst queue:architect queue:designer queue:planner queue:developer queue:reviewer; do
+  gh label create "$label" --color "#d93f0b" --force
+done
+
+# Marker labels
+gh label create "agentharness-feature" --color "#bfd4f2" --force
+gh label create "implement" --color "#c2e0c6" --force
+```
+
+---
+
+## Queue inspection
+
+Queues are GitHub Issues with a `queue:{role}` label and `state:queued` or `state:in-progress`.
+
+### List all open issues per queue (peek)
+```bash
+for queue in analyst architect designer planner developer reviewer; do
+  count=$(gh issue list --label "queue:$queue" --state open --json number --jq 'length')
+  echo "queue:$queue — $count issue(s)"
+done
+```
+
+### List queued issues for a specific queue
+```bash
+gh issue list --label "queue:analyst" --label "state:queued" --state open \
+  --json number,title,labels,createdAt \
+  --template '{{range .}}#{{.number}} {{.title}} ({{.createdAt}})\n{{end}}'
+```
+
+### Inspect a specific queue message (issue body contains JSON)
+```bash
+# Replace 42 with the issue number
+gh issue view 42 --json number,title,body,labels | python3 -c "
+import sys, json
+issue = json.load(sys.stdin)
+print('Labels:', [l['name'] for l in issue['labels']])
+# Body contains the TaskMessage JSON between markers
+body = issue['body']
+start = body.find('\`\`\`json')
+end = body.find('\`\`\`', start + 6)
+if start != -1:
+    print(json.dumps(json.loads(body[start+7:end]), indent=2))
+else:
+    print(body)
+"
+```
+
+### List in-progress issues (claimed by a worker)
+```bash
+gh issue list --label "state:in-progress" --state open \
+  --json number,title,labels,updatedAt \
+  --template '{{range .}}#{{.number}} {{.title}} (updated: {{.updatedAt}})\n{{end}}'
+```
+
+### Clear a stuck in-progress issue (release claim)
+```bash
+# Replace 42 with the issue number
+ISSUE=42
+gh issue edit $ISSUE --remove-label "state:in-progress"
+gh issue edit $ISSUE --add-label "state:queued"
+# Also remove any claimed-by label
+gh issue view $ISSUE --json labels --jq '.labels[].name' | grep "^claimed-by:" | while read label; do
+  gh issue edit $ISSUE --remove-label "$label"
+done
+```
+
+---
+
+## Feature listing
+
+Features live on branches named `feat/{feature_id}` and are tracked by issues with the `agentharness-feature` label.
+
+### List all features (via issues)
+```bash
+gh issue list --label "agentharness-feature" --state all \
+  --json number,title,labels,createdAt \
+  --template '{{range .}}#{{.number}} {{.title}}\n  Labels: {{range .labels}}{{.name}} {{end}}\n  Created: {{.createdAt}}\n\n{{end}}'
+```
+
+### List active features (not done/failed)
+```bash
+gh issue list --label "agentharness-feature" --state open \
+  --json number,title,labels,createdAt \
+  --template '{{range .}}#{{.number}} {{.title}}\n  Status: {{range .labels}}{{.name}} {{end}}\n\n{{end}}'
+```
+
+### List feature branches
+```bash
+git branch -r | grep "feat/" | sed 's|origin/||'
+```
+
+### List artifacts for a feature (files on its branch)
+```bash
+FEATURE_ID=feat-20260425-abc123
+git ls-tree -r --name-only "origin/$FEATURE_ID" -- artifacts/ 2>/dev/null || \
+  gh api "repos/{owner}/{repo}/git/trees/refs/heads/$FEATURE_ID?recursive=1" \
+    --jq '.tree[] | select(.type == "blob") | .path' | grep "^artifacts/"
+```
+
+---
+
+## Artifact inspection
+
+Artifacts are files committed to the feature branch under `artifacts/{feature_id}/`.
+
+### Read an artifact from a feature branch
+```bash
+FEATURE_ID=feat-20260425-abc123
+ARTIFACT=brief.md
+
+git show "origin/$FEATURE_ID:artifacts/$FEATURE_ID/$ARTIFACT" 2>/dev/null || \
+  gh api "repos/{owner}/{repo}/contents/artifacts/$FEATURE_ID/$ARTIFACT?ref=$FEATURE_ID" \
+    --jq '.content' | base64 -d
+```
+
+### Read state from the feature issue body
+```bash
+# Find the feature issue by title (feature ID is in the title)
+FEATURE_ID=feat-20260425-abc123
+gh issue list --label "agentharness-feature" --state all \
+  --json number,title,body \
+  --jq ".[] | select(.title | contains(\"$FEATURE_ID\")) | .body" | \
+  python3 -c "
+import sys, json
+body = sys.stdin.read()
+start = body.find('\`\`\`json')
+end = body.find('\`\`\`', start + 6)
+if start != -1:
+    print(json.dumps(json.loads(body[start+7:end].strip()), indent=2))
+else:
+    print(body)
+"
+```
+
+### List all artifacts on a feature branch
+```bash
+FEATURE_ID=feat-20260425-abc123
+git fetch origin "$FEATURE_ID" 2>/dev/null
+git ls-tree -r --name-only "FETCH_HEAD" -- "artifacts/$FEATURE_ID/"
+```
+
+---
+
+## Brief upload
+
+Upload a brief to the feature branch to seed the pipeline.
+
+### Upload brief.md for a new feature
+```bash
+FEATURE_ID=feat-$(date +%Y%m%d)-$(openssl rand -hex 3)
+BRANCH="$FEATURE_ID"
+
+# Create the branch from main
+git fetch origin main
+git push origin "origin/main:refs/heads/$BRANCH"
+
+# Encode the brief content and upload via API
+CONTENT=$(base64 -i brief.md)
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+gh api "repos/$OWNER/$REPO/contents/artifacts/$FEATURE_ID/brief.md" \
+  --method PUT \
+  --field message="feat: upload brief for $FEATURE_ID" \
+  --field content="$CONTENT" \
+  --field branch="$BRANCH"
+
+echo "Feature branch created: $FEATURE_ID"
+```
+
+### Overwrite an existing artifact
+```bash
+FEATURE_ID=feat-20260425-abc123
+ARTIFACT_PATH="artifacts/$FEATURE_ID/brief.md"
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+# Get current SHA (required for updates)
+SHA=$(gh api "repos/$OWNER/$REPO/contents/$ARTIFACT_PATH?ref=$FEATURE_ID" --jq '.sha')
+CONTENT=$(base64 -i brief.md)
+
+gh api "repos/$OWNER/$REPO/contents/$ARTIFACT_PATH" \
+  --method PUT \
+  --field message="chore: update brief for $FEATURE_ID" \
+  --field content="$CONTENT" \
+  --field branch="$FEATURE_ID" \
+  --field sha="$SHA"
+```
+
+---
+
+## Dead-letter inspection
+
+Failed tasks are GitHub Issues with the `state:dead-letter` label.
+
+### List all dead-letter issues
+```bash
+gh issue list --label "state:dead-letter" --state open \
+  --json number,title,labels,createdAt,updatedAt \
+  --template '{{range .}}#{{.number}} {{.title}}\n  Labels: {{range .labels}}{{.name}} {{end}}\n  Updated: {{.updatedAt}}\n\n{{end}}'
+```
+
+### Inspect a dead-letter issue
+```bash
+# Replace 42 with the issue number
+gh issue view 42
+```
+
+### Re-queue a dead-letter issue (after fixing the issue)
+```bash
+ISSUE=42
+
+# Remove dead-letter label, add back to the appropriate queue
+gh issue edit $ISSUE --remove-label "state:dead-letter" --remove-label "state:failed"
+gh issue edit $ISSUE --add-label "state:queued"
+
+echo "Issue #$ISSUE re-queued. The observer will pick it up on next poll."
+```
+
+### Close a dead-letter issue permanently
+```bash
+gh issue close 42 --comment "Closing dead-letter issue — feature abandoned."
+```
+
+---
+
+## State inspection
+
+### Check feature state via issue labels
+```bash
+FEATURE_ID=feat-20260425-abc123
+gh issue list --label "agentharness-feature" --state all \
+  --json number,title,labels \
+  --jq ".[] | select(.title | contains(\"$FEATURE_ID\")) | {number: .number, labels: [.labels[].name]}"
+```
+
+### Check all features and their pipeline phase
+```bash
+gh issue list --label "agentharness-feature" --state all --limit 50 \
+  --json number,title,labels \
+  --jq '.[] | {
+    id: (.title | capture("(feat-[0-9]+-[a-f0-9]+)").capture),
+    issue: .number,
+    status: ([.labels[].name | select(startswith("feat:"))] | first // "unknown")
+  }'
+```
+
+### Watch pipeline progress (poll every 10s)
+```bash
+watch -n 10 'gh issue list --label "agentharness-feature" --state open \
+  --json number,title,labels \
+  --jq ".[] | \"\(.number) \(.title) — \([.labels[].name | select(startswith(\"feat:\"))] | first)\""'
+```
+
+---
+
+## Common patterns
+
+### Full pipeline health check
+```bash
+echo "=== Queue depths ===" && \
+for queue in analyst architect designer planner developer reviewer; do
+  queued=$(gh issue list --label "queue:$queue" --label "state:queued" --state open --json number --jq 'length' 2>/dev/null || echo "?")
+  inprog=$(gh issue list --label "queue:$queue" --label "state:in-progress" --state open --json number --jq 'length' 2>/dev/null || echo "?")
+  echo "  queue:$queue — queued: $queued, in-progress: $inprog"
+done
+
+echo ""
+echo "=== Dead-letter ===" && \
+count=$(gh issue list --label "state:dead-letter" --state open --json number --jq 'length')
+[ "$count" -gt 0 ] && echo "  $count dead-letter issue(s) need attention" || echo "  None"
+
+echo ""
+echo "=== Active features ===" && \
+gh issue list --label "agentharness-feature" --state open --limit 20 \
+  --json number,title,labels \
+  --jq '.[] | "  #\(.number) \(.title) [\([.labels[].name | select(startswith("feat:"))] | first)]"'
+```
+
+### Find a stuck feature
+```bash
+# Issues in in-progress for more than 30 minutes
+gh issue list --label "state:in-progress" --state open \
+  --json number,title,updatedAt,labels \
+  --jq '.[] | select((.updatedAt | fromdateiso8601) < (now - 1800)) |
+    "#\(.number) \(.title) — stalled since \(.updatedAt)"'
+```

--- a/agentharness/data/skills/oneshot/SKILL.md
+++ b/agentharness/data/skills/oneshot/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: oneshot
+description: Start the autonomous development pipeline for a feature that has been brainstormed and uploaded. Use when the user says "oneshot", "implement", "start pipeline", "run", or provides a feature ID after a brainstorm session.
+---
+
+You start the AgentHarness autonomous pipeline for a given feature.
+
+This skill **always works inside a dedicated git worktree**. Never run the
+implementation against the main checkout — isolate the work so the user's
+primary working tree stays clean.
+
+## Naming convention
+
+Both the worktree directory and the branch it tracks **must** use the strict,
+deterministic form `feature/{issue_id}-{Title-Slug}`, where:
+
+- `{issue_id}` is the GitHub issue **number** only (e.g. `9863`). Never the
+  `feat-…` feature id, and never any other prefix.
+- `{Title-Slug}` is the issue **title** rendered as Title-Case words joined by
+  single hyphens: apostrophes stripped, every other non-alphanumeric run
+  collapsed to a hyphen, each word capitalized, truncated to ~50 chars.
+
+So for issue #9863 titled "What's This About?":
+
+- branch: `feature/9863-Whats-This-About`
+- worktree dir: `../worktrees/feature-9863-Whats-This-About` (basename
+  starts with `feature-`)
+
+Derive the slug **only** with this exact `gh` + `awk` pipeline so the name is
+always identical for the same title — do not improvise the slug:
+```bash
+ISSUE_ID={issue_number}
+SLUG=$(gh issue view "$ISSUE_ID" --json title --jq '.title' \
+  | sed -E "s/['’]//g" \
+  | sed -E 's/[^A-Za-z0-9]+/ /g' \
+  | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2)); print}' \
+  | sed -E 's/ +/-/g; s/^-+|-+$//g' \
+  | cut -c1-50 | sed -E 's/-+$//')
+BRANCH="feature/${ISSUE_ID}-${SLUG}"
+WORKTREE="../worktrees/feature-${ISSUE_ID}-${SLUG}"
+```
+
+## What you do
+
+1. Check that the user provided a feature ID (e.g. `feat-20260425-abc123`). If not, ask for it.
+
+2. Optionally show the uploaded brief so the user can confirm before starting:
+```bash
+agentharness status {feature_id}
+```
+
+3. **Mark the issue as work-in-progress.** Using the `gh` CLI, add the
+   `agent-wip` label to the feature's GitHub issue and remove the `agent` label
+   if it is present:
+```bash
+gh issue edit {issue_number} --add-label agent-wip --remove-label agent
+```
+   If the issue has no `agent` label, the `--remove-label` is a harmless no-op;
+   keep `--add-label agent-wip` regardless.
+
+4. Create and enter a dedicated worktree on the `feature/{issue_id}-{Title-Slug}`
+   branch (compute `BRANCH` and `WORKTREE` as shown in **Naming convention**):
+```bash
+git worktree add -b "$BRANCH" "$WORKTREE"
+cd "$WORKTREE"
+```
+If the branch already exists, attach to it instead:
+```bash
+git worktree add "$WORKTREE" "$BRANCH"
+```
+
+5. Start the pipeline from inside the worktree. There is **no** `agentharness
+   implement` command — the pipeline is driven by the `orchestrator`
+   agent (`.claude/agents/orchestrator.md`, installed by `agentharness init`). Follow
+   that orchestrator end to end: it runs `agentharness checkpoint init
+   {issue_number}` and then drives analyst → architect → designer → planner →
+   developer(s) → reviewer via the Task tool, using `agentharness checkpoint`
+   to track phase/task state.
+
+6. Tell the user:
+- The pipeline is now running autonomously inside the `feature/` worktree
+- They can monitor it with `agentharness watch`
+- The sequence: planner → architect → designer → developer(s) → reviewer
+- If review fails, developer tasks are automatically retried (up to 3 rounds)
+- They'll see the final result in `agentharness watch` when status changes to `done`
+
+## Finishing the work
+
+Once the implementation is complete, **from inside the worktree**:
+
+1. **Test** the code. Run the project's test suite (and any linters) and make
+   sure it passes before going further:
+```bash
+.venv/bin/pytest tests/ -v
+```
+   If tests fail, fix the issues (or report them) before committing — do not
+   push a broken build.
+
+2. **Commit** everything, including **all generated artifacts** committed under
+   the `artifacts/` folder, exactly the way the previous harness laid them out.
+   The pipeline writes every artifact to `artifacts/feat-{issue_id}/`:
+```
+artifacts/feat-{issue_id}/brief.md            # the issue brief
+artifacts/feat-{issue_id}/spec.r1.md          # analyst output
+artifacts/feat-{issue_id}/arch-review.r1.md   # architect output
+artifacts/feat-{issue_id}/design.r1.md        # designer output
+artifacts/feat-{issue_id}/task-plan.r1.md     # planner output
+artifacts/feat-{issue_id}/impl/{task}.rN.md   # developer output per task/revision
+artifacts/feat-{issue_id}/review/{task}.rN.md # reviewer output per task/revision
+artifacts/feat-{issue_id}/state.json          # checkpoint state
+```
+   Make sure this whole `artifacts/feat-{issue_id}/` tree is staged (the `.md`
+   files must end up in the commit, not just the code), then stage the rest of
+   the worktree so nothing is left behind:
+```bash
+git add -A artifacts/feat-{issue_id}    # ensure all generated .md artifacts are staged
+git add -A                              # stage code + everything else
+git commit --allow-empty -m "implement feat-{issue_id}"
+```
+   Use `--allow-empty` so this commit always becomes `HEAD`, capturing any
+   remaining artifacts. The whole-branch code review already ran inside the
+   pipeline (see the orchestrator's Code Review phase), so no external review
+   trigger is needed.
+
+3. **Push** the branch:
+```bash
+git push -u origin "$BRANCH"
+```
+   If the push fails due to a network error, retry up to 4 times with
+   exponential backoff (2s, 4s, 8s, 16s).
+
+4. **Create a pull request** with an implementation summary, and tag it with the
+   `agent` label. The summary must clearly state:
+   - **What the issue / feature was** — the problem or request being addressed.
+   - **How it was fixed / handled** — the approach taken and the key changes.
+
+   **The PR body MUST link the tracking issue with a `Closes #{issue_id}`
+   line** (using the GitHub issue number from `ISSUE_ID`). This is mandatory —
+   it is what makes GitHub auto-close the issue when the PR merges. Never open a
+   feature PR without it.
+
+   Open the PR (base = the repository default branch, head = `$BRANCH`). Capture
+   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"`
+   — this script ships beside this skill, so it is always present wherever the skill
+   is installed. It is the guarantee for **both** requirements above. Do not rely on `--label` or the
+   `Closes` template line on `gh pr create` alone; the LLM-filled body and the
+   `--label` flag are both sometimes dropped. The script adds the `agent` label,
+   injects `Closes #{issue_id}` if missing, then hard-fails if it cannot confirm
+   either.
+
+   First capture the pipeline's final code review so it can be surfaced on the PR.
+   The `## Code review` section carries the whole-branch review run inside the
+   pipeline — advisory cleanups and any unresolved correctness findings:
+```bash
+# Most recent code-review artifact (highest revision), if any.
+REVIEW_FILE=$(ls -1 artifacts/feat-{issue_id}/code-review.r*.md 2>/dev/null | sort -V | tail -n1)
+REVIEW_SECTION=""
+if [ -n "$REVIEW_FILE" ]; then
+  REVIEW_SECTION=$(printf '\n## Code review\n\n%s\n' "$(cat "$REVIEW_FILE")")
+fi
+
+PR_URL=$(gh pr create \
+  --base master \
+  --head "$BRANCH" \
+  --label agent \
+  --title "#{issue_id}: implementation" \
+  --body "$(cat <<EOF
+Closes #{issue_id}
+
+## What the issue was
+<description of the feature/problem from the brief>
+
+## How it was fixed / handled
+<summary of the approach and the main changes>
+
+## Artifacts
+- Brief, spec, design, task plan, impl, and review markdown are committed in this branch.
+${REVIEW_SECTION}
+EOF
+)")
+
+# MANDATORY: guarantee the `agent` label AND the `Closes #{issue_id}` link.
+# Auto-repairs both if the agent dropped them, then hard-fails if it cannot.
+.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"
+```
+   Substitute the real GitHub issue number for `{issue_id}` in both the title
+   and the `Closes #{issue_id}` line (same number used for `ISSUE_ID` above).
+
+5. **Mark the issue completed.** Using the `gh` CLI, remove the `agent-wip`
+   label and add the `agent-completed` label to the feature's issue:
+```bash
+gh issue edit {issue_number} --remove-label agent-wip --add-label agent-completed
+```
+
+## If something looks wrong
+
+If the user wants to adjust the brief before starting, remind them the brief is at:
+```
+artifacts/{feature_id}/brief.md
+```
+in the configured storage backend. They can download, edit, and re-upload it before calling implement.

--- a/agentharness/data/skills/oneshot/ensure_pr_linked.sh
+++ b/agentharness/data/skills/oneshot/ensure_pr_linked.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Ensure a harness-opened PR is tied to its tracking issue.
+#
+# Guarantees, idempotently, that the pull request:
+#   1. carries the `agent` label, and
+#   2. links the issue with a closing keyword (`Closes #<n>`) so merging the PR
+#      auto-closes the issue.
+#
+# Auto-repairs first (adds the label / injects a `Closes #<n>` line), then
+# verifies. Exits non-zero if it still cannot guarantee both.
+#
+# Usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>
+set -euo pipefail
+
+PR="${1:-}"
+ISSUE="${2:-}"
+
+if [[ -z "$PR" || -z "$ISSUE" ]]; then
+  echo "usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>" >&2
+  exit 2
+fi
+
+if [[ ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: issue number must be numeric, got: $ISSUE" >&2
+  exit 2
+fi
+
+# GitHub closing keywords, immediately followed by `#<issue>` and a non-digit
+# boundary (so `#1` does not match `#10`).
+CLOSE_LINK="(clos(e|es|ed)|fix(es|ed)?|resolve(s|d)?) +#${ISSUE}([^0-9]|\$)"
+
+# 1. Guarantee the `agent` label (idempotent add, then verify it landed).
+gh pr edit "$PR" --add-label agent
+if ! gh pr view "$PR" --json labels --jq '.labels[].name' | grep -qx agent; then
+  echo "ERROR: agent label missing on $PR" >&2
+  exit 1
+fi
+
+# 2. Guarantee a closing link to the issue (inject if absent, preserving body).
+body=$(gh pr view "$PR" --json body --jq '.body')
+if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
+  printf -v new_body 'Closes #%s\n\n%s' "$ISSUE" "$body"
+  gh pr edit "$PR" --body "$new_body"
+  body=$(gh pr view "$PR" --json body --jq '.body')
+  if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
+    echo "ERROR: failed to add Closes #${ISSUE} to $PR" >&2
+    exit 1
+  fi
+fi
+
+echo "PR $PR linked to issue #$ISSUE with agent label."

--- a/agentharness/data/skills/submit/SKILL.md
+++ b/agentharness/data/skills/submit/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: submit
+description: Use when the user says "submit", "submit to pipeline", or wants to send the last brainstorming spec to the AgentHarness pipeline. Finds the spec from context or disk and calls agentharness submit.
+---
+
+# Submit — Send Spec to AgentHarness Pipeline
+
+Takes the last spec written by `superpowers:brainstorming` and submits it to the AgentHarness autonomous development pipeline.
+
+## Steps
+
+### 1. Locate the spec
+
+Check in this order:
+
+1. **Current context** — was a spec file path mentioned or just written this session?
+2. **Project spec directories** — find the most recently modified spec on disk:
+
+```bash
+ls -t docs/features/*.md 2>/dev/null | head -1
+ls -t docs/superpowers/specs/*.md 2>/dev/null | head -1
+```
+
+Use whichever returns a result. If both are empty, tell the user no spec was found and stop.
+
+### 2. Submit
+
+```bash
+agentharness submit <spec-path>
+```
+
+This uploads the spec and returns a **feature ID** (e.g. `feat-20260425-abc123`).
+
+### 4. Tell the user
+
+- The feature ID
+- They can review or edit the spec at `artifacts/<feature-id>/brief.md` before starting
+- When ready: run `/oneshot <issue-number>` to start the pipeline

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -45,3 +45,14 @@ def test_init_prints_updated_message(tmp_path):
     with patch("agentharness.cli._write_env"):
         result = runner.invoke(main, ["init", "--dir", str(tmp_path)], catch_exceptions=False)
     assert "/oneshot" in result.output
+
+
+def test_init_installs_skills_as_real_files_with_pr_script(tmp_path):
+    runner = CliRunner()
+    with patch("agentharness.cli._write_env"):
+        runner.invoke(main, ["init", "--dir", str(tmp_path)], catch_exceptions=False)
+    skills = tmp_path / ".claude" / "skills"
+    brainstorm = skills / "brainstorm" / "SKILL.md"
+    assert brainstorm.is_file() and not brainstorm.is_symlink()
+    # oneshot ships with its pr-linking script so the step works in consumer repos.
+    assert (skills / "oneshot" / "ensure_pr_linked.sh").is_file()

--- a/tests/test_packaged_skills.py
+++ b/tests/test_packaged_skills.py
@@ -1,0 +1,53 @@
+"""Guards for the skills shipped by `agentharness init`.
+
+`agentharness/data/skills/` is the real, packaged source that `init` copies into a
+consumer repo's `.claude/skills/`. It must:
+  * be real files, never a symlink — symlinks ship nothing from a pip install,
+  * mirror the full set of skills in the repo's `.claude/skills/`,
+  * stay byte-identical to that source (so the shipped copy never drifts),
+  * carry the oneshot skill's `ensure_pr_linked.sh` (the pr-linking step is
+    mandatory when oneshot runs in a consumer repo — see #128).
+"""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_SKILLS = REPO_ROOT / "agentharness" / "data" / "skills"
+SOURCE_SKILLS = REPO_ROOT / ".claude" / "skills"
+
+
+def _skill_dirs(root: Path) -> set[str]:
+    return {p.name for p in root.iterdir() if p.is_dir()}
+
+
+def test_data_skills_is_not_a_symlink():
+    assert DATA_SKILLS.is_dir() and not DATA_SKILLS.is_symlink(), (
+        "agentharness/data/skills must be a real directory, not a symlink — "
+        "symlinks are not preserved in a pip-installed wheel."
+    )
+    for child in DATA_SKILLS.rglob("*"):
+        assert not child.is_symlink(), f"{child} must not be a symlink"
+
+
+def test_ships_the_full_skill_set():
+    assert _skill_dirs(DATA_SKILLS) == _skill_dirs(SOURCE_SKILLS), (
+        "packaged skills must mirror .claude/skills exactly"
+    )
+
+
+def test_pr_linking_script_ships_with_oneshot():
+    script = DATA_SKILLS / "oneshot" / "ensure_pr_linked.sh"
+    assert script.is_file(), (
+        "ensure_pr_linked.sh must ship inside the oneshot skill so the pr-linking "
+        "step works when oneshot runs in a consumer repo (#128)"
+    )
+
+
+def test_packaged_skills_match_their_source():
+    for skill in _skill_dirs(SOURCE_SKILLS):
+        src, packaged = SOURCE_SKILLS / skill, DATA_SKILLS / skill
+        src_files = {p.relative_to(src): p.read_bytes() for p in src.rglob("*") if p.is_file()}
+        pkg_files = {p.relative_to(packaged): p.read_bytes() for p in packaged.rglob("*") if p.is_file()}
+        assert src_files == pkg_files, (
+            f"packaged skill '{skill}' has drifted from .claude/skills/{skill} — "
+            "re-copy it so the shipped copy stays in sync."
+        )


### PR DESCRIPTION
`agentharness/data/skills` was a symlink to `../../.claude/skills`, which dangles in a pip-installed wheel — so `agentharness init` copied no skills at all into consumer repos. This replaces it with a real directory mirroring `.claude/skills`, so every skill is packaged and installed into the consumer's `.claude/skills/`, including `oneshot` and its bundled `ensure_pr_linked.sh` pr-linking script (#128). Adds `tests/test_packaged_skills.py` guarding the no-symlink invariant, the full packaged skill set, and byte-for-byte source/package parity, plus an `init` test asserting skills land as real files with the pr script present.