### PR TITLE
fix: always enforce the defined PR title format in oneshot

### DIFF
--- a/.claude/skills/oneshot/SKILL.md
+++ b/.claude/skills/oneshot/SKILL.md
@@ -140,13 +140,14 @@ git push -u origin "$BRANCH"
    feature PR without it.
 
    Open the PR (base = the repository default branch, head = `$BRANCH`). Capture
-   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"`
+   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "$ISSUE_ID"`
    — this script ships beside this skill, so it is always present wherever the skill
-   is installed. It is the guarantee for **both** requirements above. Do not rely on `--label` or the
-   `Closes` template line on `gh pr create` alone; the LLM-filled body and the
-   `--label` flag are both sometimes dropped. The script adds the `agent` label,
-   injects `Closes #{issue_id}` if missing, then hard-fails if it cannot confirm
-   either.
+   is installed. It is the guarantee for **all three** requirements above (label,
+   closing link, and title format). Do not rely on `--label`, the `Closes` template
+   line, or the `--title` on `gh pr create` alone; the LLM-filled body, the `--label`
+   flag, and the title are all sometimes dropped or mangled. The script adds the
+   `agent` label, injects `Closes #{issue_id}` if missing, and normalizes the title
+   to `#{issue_id}: <summary>`, then hard-fails if it cannot confirm all three.
 
    First capture the pipeline's final code review so it can be surfaced on the PR.
    The `## Code review` section carries the whole-branch review run inside the
@@ -163,9 +164,9 @@ PR_URL=$(gh pr create \
   --base master \
   --head "$BRANCH" \
   --label agent \
-  --title "#{issue_id}: implementation" \
+  --title "#${ISSUE_ID}: implementation" \
   --body "$(cat <<EOF
-Closes #{issue_id}
+Closes #${ISSUE_ID}
 
 ## What the issue was
 <description of the feature/problem from the brief>
@@ -179,12 +180,16 @@ ${REVIEW_SECTION}
 EOF
 )")
 
-# MANDATORY: guarantee the `agent` label AND the `Closes #{issue_id}` link.
-# Auto-repairs both if the agent dropped them, then hard-fails if it cannot.
-.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"
+# MANDATORY: guarantee the `agent` label, the `Closes #<n>` link, AND the
+# `#<n>: <summary>` title format. Auto-repairs all three if the agent dropped
+# or mangled them, then hard-fails if it cannot.
+.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "$ISSUE_ID"
 ```
-   Substitute the real GitHub issue number for `{issue_id}` in both the title
-   and the `Closes #{issue_id}` line (same number used for `ISSUE_ID` above).
+   The title and the `Closes` line use the `${ISSUE_ID}` shell variable set in
+   the **Naming convention** block, so they expand automatically — do not
+   hand-edit them. Substitute the real feature id for the remaining
+   `{issue_id}` artifact-path placeholders (the `artifacts/feat-{issue_id}/…`
+   lines) only.
 
 5. **Mark the issue completed.** Using the `gh` CLI, remove the `agent-wip`
    label and add the `agent-completed` label to the feature's issue:

--- a/.claude/skills/oneshot/ensure_pr_linked.sh
+++ b/.claude/skills/oneshot/ensure_pr_linked.sh
@@ -2,12 +2,13 @@
 # Ensure a harness-opened PR is tied to its tracking issue.
 #
 # Guarantees, idempotently, that the pull request:
-#   1. carries the `agent` label, and
+#   1. carries the `agent` label,
 #   2. links the issue with a closing keyword (`Closes #<n>`) so merging the PR
-#      auto-closes the issue.
+#      auto-closes the issue, and
+#   3. has a title in the defined format `#<issue>: <summary>`.
 #
-# Auto-repairs first (adds the label / injects a `Closes #<n>` line), then
-# verifies. Exits non-zero if it still cannot guarantee both.
+# Auto-repairs first (adds the label / injects a `Closes #<n>` line / normalizes
+# the title), then verifies. Exits non-zero if it still cannot guarantee all three.
 #
 # Usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>
 set -euo pipefail
@@ -48,4 +49,21 @@ if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
   fi
 fi
 
-echo "PR $PR linked to issue #$ISSUE with agent label."
+# 3. Guarantee the title follows the defined format: "#<issue>: <summary>".
+TITLE_RE="^#${ISSUE}: .+"
+title=$(gh pr view "$PR" --json title --jq '.title')
+if [[ ! "$title" =~ $TITLE_RE ]]; then
+  # Strip any leading "#<anything>:" prefix (real number or un-substituted
+  # placeholder like "#{issue_id}:"), trim, and keep the remainder as summary.
+  summary=$(sed -E 's/^#[^:]*:[[:space:]]*//' <<<"$title")
+  summary=$(sed -E 's/^[[:space:]]+|[[:space:]]+$//g' <<<"$summary")
+  [[ -z "$summary" ]] && summary="implementation"
+  gh pr edit "$PR" --title "#${ISSUE}: ${summary}"
+  title=$(gh pr view "$PR" --json title --jq '.title')
+  if [[ ! "$title" =~ $TITLE_RE ]]; then
+    echo "ERROR: failed to set title format on $PR" >&2
+    exit 1
+  fi
+fi
+
+echo "PR $PR linked to issue #$ISSUE with agent label and title \"$title\"."

--- a/agentharness/data/skills/oneshot/SKILL.md
+++ b/agentharness/data/skills/oneshot/SKILL.md
@@ -140,13 +140,14 @@ git push -u origin "$BRANCH"
    feature PR without it.
 
    Open the PR (base = the repository default branch, head = `$BRANCH`). Capture
-   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"`
+   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "$ISSUE_ID"`
    — this script ships beside this skill, so it is always present wherever the skill
-   is installed. It is the guarantee for **both** requirements above. Do not rely on `--label` or the
-   `Closes` template line on `gh pr create` alone; the LLM-filled body and the
-   `--label` flag are both sometimes dropped. The script adds the `agent` label,
-   injects `Closes #{issue_id}` if missing, then hard-fails if it cannot confirm
-   either.
+   is installed. It is the guarantee for **all three** requirements above (label,
+   closing link, and title format). Do not rely on `--label`, the `Closes` template
+   line, or the `--title` on `gh pr create` alone; the LLM-filled body, the `--label`
+   flag, and the title are all sometimes dropped or mangled. The script adds the
+   `agent` label, injects `Closes #{issue_id}` if missing, and normalizes the title
+   to `#{issue_id}: <summary>`, then hard-fails if it cannot confirm all three.
 
    First capture the pipeline's final code review so it can be surfaced on the PR.
    The `## Code review` section carries the whole-branch review run inside the
@@ -163,9 +164,9 @@ PR_URL=$(gh pr create \
   --base master \
   --head "$BRANCH" \
   --label agent \
-  --title "#{issue_id}: implementation" \
+  --title "#${ISSUE_ID}: implementation" \
   --body "$(cat <<EOF
-Closes #{issue_id}
+Closes #${ISSUE_ID}
 
 ## What the issue was
 <description of the feature/problem from the brief>
@@ -179,12 +180,16 @@ ${REVIEW_SECTION}
 EOF
 )")
 
-# MANDATORY: guarantee the `agent` label AND the `Closes #{issue_id}` link.
-# Auto-repairs both if the agent dropped them, then hard-fails if it cannot.
-.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"
+# MANDATORY: guarantee the `agent` label, the `Closes #<n>` link, AND the
+# `#<n>: <summary>` title format. Auto-repairs all three if the agent dropped
+# or mangled them, then hard-fails if it cannot.
+.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "$ISSUE_ID"
 ```
-   Substitute the real GitHub issue number for `{issue_id}` in both the title
-   and the `Closes #{issue_id}` line (same number used for `ISSUE_ID` above).
+   The title and the `Closes` line use the `${ISSUE_ID}` shell variable set in
+   the **Naming convention** block, so they expand automatically — do not
+   hand-edit them. Substitute the real feature id for the remaining
+   `{issue_id}` artifact-path placeholders (the `artifacts/feat-{issue_id}/…`
+   lines) only.
 
 5. **Mark the issue completed.** Using the `gh` CLI, remove the `agent-wip`
    label and add the `agent-completed` label to the feature's issue:

--- a/agentharness/data/skills/oneshot/ensure_pr_linked.sh
+++ b/agentharness/data/skills/oneshot/ensure_pr_linked.sh
@@ -2,12 +2,13 @@
 # Ensure a harness-opened PR is tied to its tracking issue.
 #
 # Guarantees, idempotently, that the pull request:
-#   1. carries the `agent` label, and
+#   1. carries the `agent` label,
 #   2. links the issue with a closing keyword (`Closes #<n>`) so merging the PR
-#      auto-closes the issue.
+#      auto-closes the issue, and
+#   3. has a title in the defined format `#<issue>: <summary>`.
 #
-# Auto-repairs first (adds the label / injects a `Closes #<n>` line), then
-# verifies. Exits non-zero if it still cannot guarantee both.
+# Auto-repairs first (adds the label / injects a `Closes #<n>` line / normalizes
+# the title), then verifies. Exits non-zero if it still cannot guarantee all three.
 #
 # Usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>
 set -euo pipefail
@@ -48,4 +49,21 @@ if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
   fi
 fi
 
-echo "PR $PR linked to issue #$ISSUE with agent label."
+# 3. Guarantee the title follows the defined format: "#<issue>: <summary>".
+TITLE_RE="^#${ISSUE}: .+"
+title=$(gh pr view "$PR" --json title --jq '.title')
+if [[ ! "$title" =~ $TITLE_RE ]]; then
+  # Strip any leading "#<anything>:" prefix (real number or un-substituted
+  # placeholder like "#{issue_id}:"), trim, and keep the remainder as summary.
+  summary=$(sed -E 's/^#[^:]*:[[:space:]]*//' <<<"$title")
+  summary=$(sed -E 's/^[[:space:]]+|[[:space:]]+$//g' <<<"$summary")
+  [[ -z "$summary" ]] && summary="implementation"
+  gh pr edit "$PR" --title "#${ISSUE}: ${summary}"
+  title=$(gh pr view "$PR" --json title --jq '.title')
+  if [[ ! "$title" =~ $TITLE_RE ]]; then
+    echo "ERROR: failed to set title format on $PR" >&2
+    exit 1
+  fi
+fi
+
+echo "PR $PR linked to issue #$ISSUE with agent label and title \"$title\"."

--- a/tests/test_ensure_pr_linked.py
+++ b/tests/test_ensure_pr_linked.py
@@ -38,6 +38,8 @@ if args[:2] == ["pr", "edit"]:
             state["labels"].append(label)
     if "--body" in args:
         state["body"] = args[args.index("--body") + 1]
+    if "--title" in args:
+        state["title"] = args[args.index("--title") + 1]
     save()
     sys.exit(0)
 
@@ -47,6 +49,8 @@ if args[:2] == ["pr", "view"]:
         print("\\n".join(state["labels"]))
     elif "body" in args:
         print(state["body"])
+    elif "title" in args:
+        print(state.get("title", ""))
     sys.exit(0)
 
 save()
@@ -65,10 +69,11 @@ def run_script(tmp_path):
 
     state_path = tmp_path / "state.json"
 
-    def _run(pr, issue, *, labels=None, body="", label_wont_land=False):
+    def _run(pr, issue, *, labels=None, body="", title="", label_wont_land=False):
         state = {
             "labels": list(labels or []),
             "body": body,
+            "title": title,
             "label_wont_land": label_wont_land,
             "calls": [],
         }
@@ -141,6 +146,53 @@ def test_hard_fails_when_label_cannot_land(run_script):
 
     assert proc.returncode == 1
     assert "agent label missing" in proc.stderr
+
+
+def test_repairs_bare_implementation_title(run_script):
+    # The known failure mode: the "#<n>: " prefix was dropped, leaving "implementation".
+    proc, state = run_script("42", "7", labels=["agent"], body="Closes #7", title="implementation")
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["title"] == "#7: implementation"
+
+
+def test_repairs_unsubstituted_placeholder_title(run_script):
+    # The LLM never substituted the "{issue_id}" placeholder.
+    proc, state = run_script(
+        "42", "7", labels=["agent"], body="Closes #7", title="#{issue_id}: implementation"
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["title"] == "#7: implementation"
+
+
+def test_leaves_correct_title_untouched(run_script):
+    proc, state = run_script("42", "7", labels=["agent"], body="Closes #7", title="#7: implementation")
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["title"] == "#7: implementation"
+
+
+def test_preserves_meaningful_summary(run_script):
+    proc, state = run_script("42", "7", labels=["agent"], body="Closes #7", title="#7: add rate limiter")
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["title"] == "#7: add rate limiter"
+
+
+def test_defaults_summary_when_title_empty(run_script):
+    proc, state = run_script("42", "7", labels=["agent"], body="Closes #7", title="")
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["title"] == "#7: implementation"
+
+
+def test_does_not_treat_superset_issue_number_in_title_as_match(run_script):
+    # Title references #70, but the tracking issue is #7 — must be renormalized.
+    proc, state = run_script("42", "7", labels=["agent"], body="Closes #7", title="#70: implementation")
+
+    assert proc.returncode == 0, proc.stderr
+    assert state["title"] == "#7: implementation"
 
 
 def test_script_exists_and_is_executable():

--- a/tests/test_pipeline_review_wiring.py
+++ b/tests/test_pipeline_review_wiring.py
@@ -47,3 +47,18 @@ def test_oneshot_skill_invokes_ensure_pr_linked():
 def test_ensure_pr_linked_script_exists_and_is_executable():
     assert ENSURE_PR_LINKED.exists()
     assert os.access(ENSURE_PR_LINKED, os.X_OK)
+
+
+def test_oneshot_skill_uses_issue_id_variable_in_pr_title():
+    # The title must use the real $ISSUE_ID shell var, not the brittle
+    # "{issue_id}" placeholder the LLM had to hand-substitute (which sometimes
+    # collapsed the title to a bare "implementation").
+    body = ONESHOT.read_text(encoding="utf-8")
+    assert '--title "#${ISSUE_ID}: implementation"' in body
+    assert '--title "#{issue_id}: implementation"' not in body
+
+
+def test_ensure_pr_linked_enforces_title_format():
+    script = ENSURE_PR_LINKED.read_text(encoding="utf-8")
+    assert 'gh pr edit "$PR" --title' in script
+    assert 'TITLE_RE="^#${ISSUE}: .+"' in script


### PR DESCRIPTION
Harness-opened PRs sometimes ended up titled just `implementation` because the oneshot skill's title used a `#{issue_id}:` brace placeholder the agent had to hand-substitute, and when it dropped the prefix only the hardcoded suffix survived. `ensure_pr_linked.sh` now guarantees the title matches the defined `#<issue>: <summary>` format the same deterministic way it already guarantees the `agent` label and `Closes #<n>` link (read → repair → re-verify → hard-fail), defaulting the summary to `implementation` while preserving a meaningful one. The oneshot `SKILL.md` also now uses the real `\$ISSUE_ID` shell variable in the title, `Closes` line, and script call so the first attempt is already correct. Added title-repair unit tests plus regression guards, and kept the live and packaged skill copies byte-identical. Full suite passes (138 passed, 2 skipped).